### PR TITLE
Fix incorrect handling for GetSourceTips when SCM is not present

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -318,9 +318,9 @@ SCM_TIP_FILECMD := $(PRINTF) "$(SCM):%s" \
 # Emit the scm:id pair to $@
 define GetSourceTips
 	$(CD) $(SRC_ROOT) ; \
-	if [ -d $(SCM_DIR) -a "$(SCM_VERSION)" != "" ] ; then \
+	if [ -d "$(SCM_DIR)" -a "$(SCM_VERSION)" != "" ] ; then \
 	  $(ID_COMMAND) >> $@ ; \
-	elif [ -f $(SCM_TIP_FILENAME) ] ; then \
+	elif [ -f "$(SCM_TIP_FILENAME)" ] ; then \
           $(SCM_TIP_FILECMD) >> $@ ; \
 	fi;
 	$(PRINTF) "\n" >> $@


### PR DESCRIPTION
This patch should fix the `/bin/sh: line 1: [: too many arguments` error when building OpenJDK 8u from a release tarball.

OCA: I have previously signed an OCA under the email and legal name provided in the `Signed-off-by` field.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u pull/6/head:pull/6` \
`$ git checkout pull/6`

Update a local copy of the PR: \
`$ git checkout pull/6` \
`$ git pull https://git.openjdk.java.net/jdk8u pull/6/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 6`

View PR using the GUI difftool: \
`$ git pr show -t 6`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u/pull/6.diff">https://git.openjdk.java.net/jdk8u/pull/6.diff</a>

</details>
