### PR TITLE
8285591: [11] add signum checks in DSA.java engineVerify

### DIFF
--- a/jdk/src/share/classes/sun/security/provider/DSA.java
+++ b/jdk/src/share/classes/sun/security/provider/DSA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -299,7 +299,8 @@ abstract class DSA extends SignatureSpi {
             s = new BigInteger(1, s.toByteArray());
         }
 
-        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)) {
+        if ((r.compareTo(presetQ) == -1) && (s.compareTo(presetQ) == -1)
+                && r.signum() > 0 && s.signum() > 0) {
             BigInteger w = generateW(presetP, presetQ, presetG, s);
             BigInteger v = generateV(presetY, presetP, presetQ, presetG, w, r);
             return v.equals(r);


### PR DESCRIPTION
This change was part of a security fix, JDK-8277233, for 17u during the April update.  The rest of 8277233 did not apply to older releases, as it concerned code added to ` src/jdk.crypto.ec/share/classes/sun/security/ec/ECDSAOperations.java` by JDK-8237218 in 15u.

However, the additional checks in `src/java.base/share/classes/sun/security/provider/DSA.java` that were included in the patch are applicable to older releases.

I'm raising this for inclusion in 8u342 during rampdown as 17u already has it since the April update and 11u now has this backport. It would be good for 8u to be consistent as soon as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer), 1 [Author](https://openjdk.java.net/bylaws#author))

### Issue
 * [JDK-8285591](https://bugs.openjdk.java.net/browse/JDK-8285591): [11] add signum checks in DSA.java engineVerify


### Reviewers
 * [Severin Gehwolf](https://openjdk.java.net/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Martin Balao](https://openjdk.java.net/census#mbalao) (@martinuy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk8u pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jdk8u pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk8u/pull/11.diff">https://git.openjdk.java.net/jdk8u/pull/11.diff</a>

</details>
