### PR TITLE
8296715: CLDR v42 update for tzdata 2022f

### DIFF
--- a/jdk/src/share/classes/sun/util/cldr/resources/21_0_1/common/supplemental/metaZones.xml
+++ b/jdk/src/share/classes/sun/util/cldr/resources/21_0_1/common/supplemental/metaZones.xml
@@ -317,8 +317,9 @@
 				<usesMetazone mzone="America_Central"/>
 			</timezone>
 			<timezone type="America/Chihuahua">
-				<usesMetazone to="1998-04-05 09:00" mzone="America_Central"/>
-				<usesMetazone from="1998-04-05 09:00" mzone="America_Mountain"/>
+ 				<usesMetazone to="1998-04-05 09:00" mzone="America_Central"/>
+				<usesMetazone to="2022-10-30 08:00" from="1998-04-05 09:00" mzone="America_Mountain"/>
+				<usesMetazone from="2022-10-30 08:00" mzone="America_Central"/>
 			</timezone>
 			<timezone type="America/Coral_Harbour">
 				<usesMetazone mzone="America_Eastern"/>
@@ -596,8 +597,9 @@
 				<usesMetazone from="2003-10-26 08:00" mzone="America_Central"/>
 			</timezone>
 			<timezone type="America/Ojinaga">
-				<usesMetazone to="1998-04-05 09:00" mzone="America_Central"/>
-				<usesMetazone from="1998-04-05 09:00" mzone="America_Mountain"/>
+ 				<usesMetazone to="1998-04-05 09:00" mzone="America_Central"/>
+				<usesMetazone to="2022-10-30 08:00" from="1998-04-05 09:00" mzone="America_Mountain"/>
+				<usesMetazone from="2022-10-30 08:00" mzone="America_Central"/>
 			</timezone>
 			<timezone type="America/Panama">
 				<usesMetazone mzone="America_Eastern"/>


### PR DESCRIPTION
This is a minimal backport of the CLDR v42 update for tzdata 2022f, just containing the timezone changes. The previous definition for `America/Chihuahua`, which is superseded by the change to `America_Central` on 2022-10-30, is retained as `America_Mountain` as `Mexico_Pacific` doesn't exist in 8u's version of CLDR and the change here is to define an end to that metazone, not alter it.

The other changes are omitted as follows:

* The `es_419.xml` in 8u's CLDR does not contain the patterns being altered.
* `LocaleData.cldr` does not exist in 8u
* `LocaleDataTest.java` does not need updating as the test has not been changed, as there is no data file change (`LocaleData.cldr`)

Regarding the latter two, the CLDR checks in the test were introduced as part of JDK-8008577: "Use CLDR Locale Data by Default". We obviously don't want to backport that in full, but updating LocaleDataTest.java with a CLDR data set would be useful.

However, I think it's out of scope for a rampdown time critical data fix like this, as it is likely a lengthy effort to get a passing data set, needing further CLDR updates. It should be handled separately. I'll open a bug and PR for this against 8u-dev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296715](https://bugs.openjdk.org/browse/JDK-8296715): CLDR v42 update for tzdata 2022f


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/jdk8u pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/27.diff">https://git.openjdk.org/jdk8u/pull/27.diff</a>

</details>
