### PR TITLE
8225687: Newly added sspi.cpp in JDK-6722928 still contains some small errors

### DIFF
--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeFunc.h
@@ -57,8 +57,8 @@ typedef OM_uint32 (*RELEASE_NAME_FN_PTR)
 
 typedef OM_uint32 (*IMPORT_NAME_FN_PTR)
                                 (OM_uint32 *minor_status,
-                                const gss_buffer_t input_name_buffer,
-                                const gss_OID input_name_type,
+                                gss_const_buffer_t input_name_buffer,
+                                gss_const_OID input_name_type,
                                 gss_name_t *output_name);
 
 typedef OM_uint32 (*COMPARE_NAME_FN_PTR)
@@ -70,7 +70,7 @@ typedef OM_uint32 (*COMPARE_NAME_FN_PTR)
 typedef OM_uint32 (*CANONICALIZE_NAME_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_const_name_t input_name,
-                                const gss_OID mech_type,
+                                gss_const_OID mech_type,
                                 gss_name_t *output_name);
 
 typedef OM_uint32 (*EXPORT_NAME_FN_PTR)
@@ -88,7 +88,7 @@ typedef OM_uint32 (*ACQUIRE_CRED_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_const_name_t desired_name,
                                 OM_uint32 time_req,
-                                const gss_OID_set desired_mech,
+                                gss_const_OID_set desired_mech,
                                 gss_cred_usage_t cred_usage,
                                 gss_cred_id_t *output_cred_handle,
                                 gss_OID_set *actual_mechs,
@@ -108,7 +108,7 @@ typedef OM_uint32 (*INQUIRE_CRED_FN_PTR)
 
 typedef OM_uint32 (*IMPORT_SEC_CONTEXT_FN_PTR)
                                 (OM_uint32 *minor_status,
-                                const gss_buffer_t interprocess_token,
+                                gss_const_buffer_t interprocess_token,
                                 gss_ctx_id_t *context_handle);
 
 typedef OM_uint32 (*INIT_SEC_CONTEXT_FN_PTR)
@@ -116,11 +116,11 @@ typedef OM_uint32 (*INIT_SEC_CONTEXT_FN_PTR)
                                 gss_const_cred_id_t initiator_cred_handle,
                                 gss_ctx_id_t *context_handle,
                                 gss_const_name_t target_name,
-                                const gss_OID mech_type,
+                                gss_const_OID mech_type,
                                 OM_uint32 req_flags,
                                 OM_uint32 time_req,
-                                const gss_channel_bindings_t input_chan_bindings,
-                                const gss_buffer_t input_token,
+                                gss_const_channel_bindings_t input_chan_bindings,
+                                gss_const_buffer_t input_token,
                                 gss_OID *actual_mech_type,
                                 gss_buffer_t output_token,
                                 OM_uint32 *ret_flags,
@@ -130,8 +130,8 @@ typedef OM_uint32 (*ACCEPT_SEC_CONTEXT_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_ctx_id_t *context_handle,
                                 gss_const_cred_id_t acceptor_cred_handle,
-                                const gss_buffer_t input_token,
-                                const gss_channel_bindings_t input_chan_bindings,
+                                gss_const_buffer_t input_token,
+                                gss_const_channel_bindings_t input_chan_bindings,
                                 gss_name_t *src_name,
                                 gss_OID *mech_type,
                                 gss_buffer_t output_token,
@@ -177,14 +177,14 @@ typedef OM_uint32 (*GET_MIC_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_const_ctx_id_t context_handle,
                                 gss_qop_t qop_req,
-                                const gss_buffer_t message_buffer,
+                                gss_const_buffer_t message_buffer,
                                 gss_buffer_t msg_token);
 
 typedef OM_uint32 (*VERIFY_MIC_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_const_ctx_id_t context_handle,
-                                const gss_buffer_t message_buffer,
-                                const gss_buffer_t token_buffer,
+                                gss_const_buffer_t message_buffer,
+                                gss_const_buffer_t token_buffer,
                                 gss_qop_t *qop_state);
 
 typedef OM_uint32 (*WRAP_FN_PTR)
@@ -192,14 +192,14 @@ typedef OM_uint32 (*WRAP_FN_PTR)
                                 gss_const_ctx_id_t context_handle,
                                 int conf_req_flag,
                                 gss_qop_t qop_req,
-                                const gss_buffer_t input_message_buffer,
+                                gss_const_buffer_t input_message_buffer,
                                 int *conf_state,
                                 gss_buffer_t output_message_buffer);
 
 typedef OM_uint32 (*UNWRAP_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 gss_const_ctx_id_t context_handle,
-                                const gss_buffer_t input_message_buffer,
+                                gss_const_buffer_t input_message_buffer,
                                 gss_buffer_t output_message_buffer,
                                 int *conf_state,
                                 gss_qop_t *qop_state);
@@ -210,19 +210,19 @@ typedef OM_uint32 (*INDICATE_MECHS_FN_PTR)
 
 typedef OM_uint32 (*INQUIRE_NAMES_FOR_MECH_FN_PTR)
                                 (OM_uint32 *minor_status,
-                                const gss_OID mechanism,
+                                gss_const_OID mechanism,
                                 gss_OID_set *name_types);
 
 typedef OM_uint32 (*ADD_OID_SET_MEMBER_FN_PTR)
                                 (OM_uint32 *minor_status,
-                                const gss_OID member_oid,
+                                gss_const_OID member_oid,
                                 gss_OID_set *oid_set);
 
 typedef OM_uint32 (*DISPLAY_STATUS_FN_PTR)
                                 (OM_uint32 *minor_status,
                                 OM_uint32 status_value,
                                 int status_type,
-                                const gss_OID mech_type,
+                                gss_const_OID mech_type,
                                 OM_uint32 *message_context,
                                 gss_buffer_t status_string);
 

--- a/jdk/src/share/native/sun/security/jgss/wrapper/gssapi.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/gssapi.h
@@ -404,7 +404,7 @@ GSS_DLLIMP OM_uint32 gss_acquire_cred(
         OM_uint32 *,            /* minor_status */
         gss_const_name_t,       /* desired_name */
         OM_uint32,              /* time_req */
-        const gss_OID_set,      /* desired_mechs */
+        gss_const_OID_set,      /* desired_mechs */
         gss_cred_usage_t,       /* cred_usage */
         gss_cred_id_t *,        /* output_cred_handle */
         gss_OID_set *,          /* actual_mechs */
@@ -421,11 +421,11 @@ GSS_DLLIMP OM_uint32 gss_init_sec_context(
         gss_const_cred_id_t,    /* claimant_cred_handle */
         gss_ctx_id_t *,         /* context_handle */
         gss_const_name_t,       /* target_name */
-        const gss_OID,          /* mech_type */
+        gss_const_OID,          /* mech_type */
         OM_uint32,              /* req_flags */
         OM_uint32,              /* time_req */
-        const gss_channel_bindings_t, /* input_chan_bindings */
-        const gss_buffer_t,     /* input_token */
+        gss_const_channel_bindings_t, /* input_chan_bindings */
+        gss_const_buffer_t,     /* input_token */
         gss_OID *,              /* actual_mech_type */
         gss_buffer_t,           /* output_token */
         OM_uint32 *,            /* ret_flags */
@@ -436,8 +436,8 @@ GSS_DLLIMP OM_uint32 gss_accept_sec_context(
         OM_uint32 *,            /* minor_status */
         gss_ctx_id_t *,         /* context_handle */
         gss_const_cred_id_t,    /* acceptor_cred_handle */
-        const gss_buffer_t,     /* input_token_buffer */
-        const gss_channel_bindings_t, /* input_chan_bindings */
+        gss_const_buffer_t,     /* input_token_buffer */
+        gss_const_channel_bindings_t, /* input_chan_bindings */
         gss_name_t *,           /* src_name */
         gss_OID *,              /* mech_type */
         gss_buffer_t,           /* output_token */
@@ -449,7 +449,7 @@ GSS_DLLIMP OM_uint32 gss_accept_sec_context(
 GSS_DLLIMP OM_uint32 gss_process_context_token(
         OM_uint32 *,            /* minor_status */
         gss_const_ctx_id_t,     /* context_handle */
-        const gss_buffer_t      /* token_buffer */
+        gss_const_buffer_t      /* token_buffer */
 );
 
 GSS_DLLIMP OM_uint32 gss_delete_sec_context(
@@ -469,7 +469,7 @@ GSS_DLLIMP OM_uint32 gss_get_mic(
         OM_uint32 *,            /* minor_status */
         gss_const_ctx_id_t,     /* context_handle */
         gss_qop_t,              /* qop_req */
-        const gss_buffer_t,     /* message_buffer */
+        gss_const_buffer_t,     /* message_buffer */
         gss_buffer_t            /* message_token */
 );
 
@@ -477,8 +477,8 @@ GSS_DLLIMP OM_uint32 gss_get_mic(
 GSS_DLLIMP OM_uint32 gss_verify_mic(
         OM_uint32 *,            /* minor_status */
         gss_const_ctx_id_t,     /* context_handle */
-        const gss_buffer_t,     /* message_buffer */
-        const gss_buffer_t,     /* message_token */
+        gss_const_buffer_t,     /* message_buffer */
+        gss_const_buffer_t,     /* message_token */
         gss_qop_t *             /* qop_state */
 );
 
@@ -488,7 +488,7 @@ GSS_DLLIMP OM_uint32 gss_wrap(
         gss_const_ctx_id_t,     /* context_handle */
         int,                    /* conf_req_flag */
         gss_qop_t,              /* qop_req */
-        const gss_buffer_t,     /* input_message_buffer */
+        gss_const_buffer_t,     /* input_message_buffer */
         int *,                  /* conf_state */
         gss_buffer_t            /* output_message_buffer */
 );
@@ -497,7 +497,7 @@ GSS_DLLIMP OM_uint32 gss_wrap(
 GSS_DLLIMP OM_uint32 gss_unwrap(
         OM_uint32 *,            /* minor_status */
         gss_const_ctx_id_t,     /* context_handle */
-        const gss_buffer_t,     /* input_message_buffer */
+        gss_const_buffer_t,     /* input_message_buffer */
         gss_buffer_t,           /* output_message_buffer */
         int *,                  /* conf_state */
         gss_qop_t *             /* qop_state */
@@ -507,7 +507,7 @@ GSS_DLLIMP OM_uint32 gss_display_status(
         OM_uint32 *,            /* minor_status */
         OM_uint32,              /* status_value */
         int,                    /* status_type */
-        const gss_OID,          /* mech_type (used to be const) */
+        gss_const_OID,          /* mech_type (used to be const) */
         OM_uint32 *,            /* message_context */
         gss_buffer_t            /* status_string */
 );
@@ -533,8 +533,8 @@ GSS_DLLIMP OM_uint32 gss_display_name(
 
 GSS_DLLIMP OM_uint32 gss_import_name(
         OM_uint32 *,            /* minor_status */
-        const gss_buffer_t,     /* input_name_buffer */
-        const gss_OID,          /* input_name_type(used to be const) */
+        gss_const_buffer_t,     /* input_name_buffer */
+        gss_const_OID,          /* input_name_type(used to be const) */
         gss_name_t *            /* output_name */
 );
 
@@ -590,7 +590,7 @@ GSS_DLLIMP OM_uint32 gss_add_cred(
         OM_uint32 *,            /* minor_status */
         gss_const_cred_id_t,    /* input_cred_handle */
         gss_const_name_t,       /* desired_name */
-        const gss_OID,          /* desired_mech */
+        gss_const_OID,          /* desired_mech */
         gss_cred_usage_t,       /* cred_usage */
         OM_uint32,              /* initiator_time_req */
         OM_uint32,              /* acceptor_time_req */
@@ -604,7 +604,7 @@ GSS_DLLIMP OM_uint32 gss_add_cred(
 GSS_DLLIMP OM_uint32 gss_inquire_cred_by_mech(
         OM_uint32 *,            /* minor_status */
         gss_const_cred_id_t,    /* cred_handle */
-        const gss_OID,          /* mech_type */
+        gss_const_OID,          /* mech_type */
         gss_name_t *,           /* name */
         OM_uint32 *,            /* initiator_lifetime */
         OM_uint32 *,            /* acceptor_lifetime */
@@ -621,7 +621,7 @@ GSS_DLLIMP OM_uint32 gss_export_sec_context(
 /* New for V2 */
 GSS_DLLIMP OM_uint32 gss_import_sec_context(
         OM_uint32 *,            /* minor_status */
-        const gss_buffer_t,     /* interprocess_token */
+        gss_const_buffer_t,     /* interprocess_token */
         gss_ctx_id_t *          /* context_handle */
 );
 
@@ -640,22 +640,22 @@ GSS_DLLIMP OM_uint32 gss_create_empty_oid_set(
 /* New for V2 */
 GSS_DLLIMP OM_uint32 gss_add_oid_set_member(
         OM_uint32 *,            /* minor_status */
-        const gss_OID,          /* member_oid */
+        gss_const_OID,          /* member_oid */
         gss_OID_set *           /* oid_set */
 );
 
 /* New for V2 */
 GSS_DLLIMP OM_uint32 gss_test_oid_set_member(
         OM_uint32 *,            /* minor_status */
-        const gss_OID,          /* member */
-        const gss_OID_set,      /* set */
+        gss_const_OID,          /* member */
+        gss_const_OID_set,      /* set */
         int *                   /* present */
 );
 
 /* New for V2 */
 GSS_DLLIMP OM_uint32 gss_str_to_oid(
         OM_uint32 *,            /* minor_status */
-        const gss_buffer_t,     /* oid_str */
+        gss_const_buffer_t,     /* oid_str */
         gss_OID *               /* oid */
 );
 
@@ -669,7 +669,7 @@ GSS_DLLIMP OM_uint32 gss_oid_to_str(
 /* New for V2 */
 GSS_DLLIMP OM_uint32 gss_inquire_names_for_mech(
         OM_uint32 *,            /* minor_status */
-        const gss_OID,          /* mechanism */
+        gss_const_OID,          /* mechanism */
         gss_OID_set *           /* name_types */
 );
 
@@ -691,7 +691,7 @@ GSS_DLLIMP OM_uint32 gss_duplicate_name(
 GSS_DLLIMP OM_uint32 gss_canonicalize_name(
         OM_uint32  *,           /* minor_status */
         gss_const_name_t,       /* input_name */
-        const gss_OID,          /* mech_type */
+        gss_const_OID,          /* mech_type */
         gss_name_t *            /* output_name */
 );
 


### PR DESCRIPTION
This is a follow-up fix for JDK-6722928.
Clean backport from JDK11

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225687](https://bugs.openjdk.org/browse/JDK-8225687): Newly added sspi.cpp in JDK-6722928 still contains some small errors (**Bug** - P3)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/47.diff">https://git.openjdk.org/jdk8u/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/47#issuecomment-1699271228)