### PR TITLE
8331791: [8u] AIX build break from JDK-8320005 backport

### DIFF
--- a/hotspot/src/os/aix/vm/os_aix.cpp
+++ b/hotspot/src/os/aix/vm/os_aix.cpp
@@ -1497,7 +1497,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }
-  FREE_C_HEAP_ARRAY(char, file_path);
+  FREE_C_HEAP_ARRAY(char, file_path, mtInternal);
   return result;
 }
 


### PR DESCRIPTION
https://github.com/openjdk/jdk8u/commit/c1c8064ef0f67e85cb6a28990f4784271d949a08
introduces a new call to the macro FREE_C_HEAP_ARRAY
but is not using the correct number of arguments.
jdk8u FREE_C_HEAP_ARRAY takes 3 arguments
JBS-ISSUE: [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791) needs maintainer approval

### Issue
 * [JDK-8331791](https://bugs.openjdk.org/browse/JDK-8331791): [8u] AIX build break from JDK-8320005 backport (**Bug** - P1)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/55.diff">https://git.openjdk.org/jdk8u/pull/55.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/55#issuecomment-2098964050)