### PR TITLE
Modify warning messages that appear in the TRACE function

### DIFF
--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
+++ b/jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
@@ -26,8 +26,12 @@
 #include <jni.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _MSC_VER
 #if _MSC_VER >= 1800
 # include <inttypes.h>
+#endif
+#else
+#include <inttypes.h>
 #endif
 #include "gssapi.h"
 
@@ -94,11 +98,13 @@ extern "C" {
   #define TRACE3(s, p1, p2, p3) { if (JGSS_DEBUG) { printf("[GSSLibStub:%d] "s"\n", __LINE__, p1, p2, p3); fflush(stdout); }}
 
   // Visual Studio 2010-2012 doesn't provide inttypes.h so provide appropriate definitions here.
+  #ifdef _MSC_VER
   #if _MSC_VER < 1800
   #ifdef _LP64
   #define PRIuPTR       "I64u"
   #else
   #define PRIuPTR       "u"
+  #endif
   #endif
   #endif
 


### PR DESCRIPTION
hi @mdinacci @gnu-andrew ,
  
When compiling jdk8u from x86_64, there is an alarm message as shown below.
jdk/src/share/native/sun/security/jgss/wrapper/GSSLibStub.c:719:3: note: in expansion of macro ‘TRACE1’
719 |   TRACE1("[GSSLibStub_getCredName] pName=%" PRIuPTR "", (uintptr_t) nameHdl);
    |   ^~~~~~
jdk/src/share/native/sun/security/jgss/wrapper/GSSLibStub.c: In function ‘Java_sun_security_jgss_wrapper_GSSLibStub_importContext’:
jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h:92:52: warning: format ‘%u’ expects argument of type ‘unsigned int’, but argument 3 has type ‘long unsigned int’ [-Wformat=]


PRIuPTR is redefined in jdk/src/share/native/sun/security/jgss/wrapper/NativeUtil.h
#if _MSC_VER >= 1800
#include<inttypes.h>
#endif

// Visual Studio 2010-2012 doesn't provide inttypes.h so provide appropriate definitions here.
#if _MSC_VER < 1800
#ifdef _LP64
#define PRIuPTR       "I64u"
#else
#define PRIuPTR       "u"
#endif
#endif


Upon checking the code, it was found that the custom macro PRIuPTR was used in the Linux system. The header file # include<inttypes.h> should be used in linux.
There are two solutions, one is limit the usage range of custom macros to visual studio 2010-2012.and the other is remove special macro definitions related to _MSC_VER.

Is this issue a bug? If it is a bug, can you create a problem on JBS. thank you!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/58.diff">https://git.openjdk.org/jdk8u/pull/58.diff</a>

</details>
