### PR TITLE
8342822: jdk8u432-b06 does not compile on AIX

### DIFF
--- a/hotspot/src/share/vm/opto/superword.hpp
+++ b/hotspot/src/share/vm/opto/superword.hpp
@@ -31,6 +31,10 @@
 #include "opto/vectornode.hpp"
 #include "utilities/growableArray.hpp"
 
+#ifdef AIX
+#include "cstdlib"
+#endif
+
 //
 //                  S U P E R W O R D   T R A N S F O R M
 //


### PR DESCRIPTION
Build error on AIX could be resolved with the addition of header file <cstdlib> which could be guarded with ifdef to make it aix-specific. Jtreg testing for hotspot/test on aix-ppc64 is successful with no related failures.

JBS : [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822) needs maintainer approval

### Issue
 * [JDK-8342822](https://bugs.openjdk.org/browse/JDK-8342822): jdk8u432-b06 does not compile on AIX (**Bug** - P2 - Approved)


### Reviewers
 * [Andrew John Hughes](https://openjdk.org/census#andrew) (@gnu-andrew - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/65/head:pull/65` \
`$ git checkout pull/65`

Update a local copy of the PR: \
`$ git checkout pull/65` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/65/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 65`

View PR using the GUI difftool: \
`$ git pr show -t 65`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/65.diff">https://git.openjdk.org/jdk8u/pull/65.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/65#issuecomment-2558172939)
</details>
