### PR TITLE
8352097: (tz) zone.tab update missed in 2025a backport

### DIFF
--- a/jdk/make/data/tzdata/zone.tab
+++ b/jdk/make/data/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon

--- a/jdk/test/sun/util/calendar/zi/tzdata/zone.tab
+++ b/jdk/test/sun/util/calendar/zi/tzdata/zone.tab
@@ -333,7 +333,7 @@ PF	-0900-13930	Pacific/Marquesas	Marquesas Islands
 PF	-2308-13457	Pacific/Gambier	Gambier Islands
 PG	-0930+14710	Pacific/Port_Moresby	most of Papua New Guinea
 PG	-0613+15534	Pacific/Bougainville	Bougainville
-PH	+1435+12100	Asia/Manila
+PH	+143512+1205804	Asia/Manila
 PK	+2452+06703	Asia/Karachi
 PL	+5215+02100	Europe/Warsaw
 PM	+4703-05620	America/Miquelon


### PR DESCRIPTION
As with https://github.com/openjdk/jdk21u/pull/460, https://github.com/openjdk/jdk17u/pull/405 & https://github.com/openjdk/jdk11u/pull/101, the [8u backport](https://git.openjdk.org/jdk8u/commit/93122abf52afbd4e3c2de26561a4b3e78918ce14) of the tzdata 2025a update missed an update to zone.tab, as this was not present in the [25u commit](https://git.openjdk.org/jdk/commit/caa3c78f7837b1f561740184bd8f9cb671c467eb) on which it was originally based, due to its removal in [JDK-8166983](https://bugs.openjdk.org/browse/JDK-8166983). The change was in [the 24u commit](https://git.openjdk.org/jdk24u/commit/81252ef76899ad95197550a11c2786ccf3cf0cd2) which was applied later than the 21u one.

We should add this missing change to the existing 2025a update in 8u452 and consider backporting JDK-8166983 for 8u462 (now proposed for 24 in https://github.com/openjdk/jdk24u/pull/150).

Patch from 11u applies cleanly to the `make/data` file when applied from the `jdk` subdirectory (`-p1`) and to the copy in `test/sun/util/calendar/zi/tzdata` applied from `test/sun/util/calendar/zi` subdirectory (`-p3`) .

Testing showed no regressions:
~~~
$ for suite in jdk_time jdk_text jdk_util_other; do make -C $HOME/builder/8u test TEST="${suite}"; done 2>&1 | tee ${TMPDIR}/test.log
...
$ cat ${TMPDIR}/test.log|grep '^TEST'
TEST STATS: name=jdk_time  run=170  pass=170  fail=0
TEST: java/text/BreakIterator/BreakIteratorTest.java
TEST JDK: /home/andrew/builder/8u/images/j2sdk-image
TEST RESULT: Failed. Execution failed: `main' threw exception: java.lang.RuntimeException: Uncaught exception thrown in test method TestJapaneseLineBreak
TEST STATS: name=jdk_text  run=152  pass=151  fail=1
TEST STATS: name=jdk_util_other  run=351  pass=351  fail=0
~~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8352097](https://bugs.openjdk.org/browse/JDK-8352097) needs maintainer approval

### Issue
 * [JDK-8352097](https://bugs.openjdk.org/browse/JDK-8352097): (tz) zone.tab update missed in 2025a backport (**Bug** - P4 - Approved)


### Reviewers
 * [Dmitry Cherepanov](https://openjdk.org/census#dcherepanov) (@dimitryc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/71.diff">https://git.openjdk.org/jdk8u/pull/71.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/71#issuecomment-2756077556)
</details>
