### PR TITLE
8348228: Major performance regression in GetMethodDeclaringClass and other JVMTI Method functions

### DIFF
--- a/hotspot/src/share/vm/oops/method.cpp
+++ b/hotspot/src/share/vm/oops/method.cpp
@@ -1903,9 +1903,6 @@ bool Method::is_method_id(jmethodID mid) {
 
 Method* Method::checked_resolve_jmethod_id(jmethodID mid) {
   if (mid == NULL) return NULL;
-  if (!Method::is_method_id(mid)) {
-    return NULL;
-  }
   Method* o = resolve_jmethod_id(mid);
   if (o == NULL || o == JNIMethodBlock::_free_method || !((Metadata*)o)->is_method()) {
     return NULL;

--- a/hotspot/src/share/vm/prims/jniCheck.cpp
+++ b/hotspot/src/share/vm/prims/jniCheck.cpp
@@ -468,6 +468,11 @@ Method* jniCheck::validate_jmethod_id(JavaThread* thr, jmethodID method_id) {
   if (moop == NULL) {
     ReportJNIFatalError(thr, fatal_wrong_class_or_method);
   }
+  // jmethodIDs are supposed to be weak handles in the class loader data,
+  // but that can be expensive so check it last
+  else if (!Method::is_method_id(method_id)) {
+    ReportJNIFatalError(thr, fatal_non_weak_method);
+  }
   return moop;
 }
 


### PR DESCRIPTION
Please review this patch for the parity of Oracle's [JDK-8185348](https://bugs.openjdk.org/browse/JDK-8185348).

Oracle's patch is non-public. This patch is based on @sspitsyn's comments in JDK-8185348 and consistent with JDK9's implementation.

Before patch, slowjvmti test case from JDK-8185348:
16366ms

After patch:
3ms

PR for jdk8u-dev has been approved: https://github.com/openjdk/jdk8u-dev/pull/656

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8348228](https://bugs.openjdk.org/browse/JDK-8348228) needs maintainer approval

### Issue
 * [JDK-8348228](https://bugs.openjdk.org/browse/JDK-8348228): Major performance regression in GetMethodDeclaringClass and other JVMTI Method functions (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/76.diff">https://git.openjdk.org/jdk8u/pull/76.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/76#issuecomment-2996536835)
</details>
