### PR TITLE
8348760: RadioButton is not shown if JRadioButtonMenuItem is rendered with ImageIcon in WindowsLookAndFeel

### DIFF
--- a/jdk/src/share/classes/com/sun/java/swing/SwingUtilities3.java
+++ b/jdk/src/share/classes/com/sun/java/swing/SwingUtilities3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,12 +35,21 @@ import java.util.WeakHashMap;
 import java.util.concurrent.Callable;
 import java.applet.Applet;
 import java.awt.AWTEvent;
-import java.awt.EventQueue;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
+import java.awt.EventQueue;
+import java.awt.Graphics;
+import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.Window;
+import javax.swing.ButtonModel;
+import javax.swing.Icon;
 import javax.swing.JComponent;
+import javax.swing.JMenu;
 import javax.swing.RepaintManager;
+import sun.swing.MenuItemLayoutHelper;
+import sun.swing.SwingUtilities2;
 
 /**
  * A collection of utility methods for Swing.
@@ -60,6 +69,10 @@ public class SwingUtilities3 {
      */
     private static final Object DELEGATE_REPAINT_MANAGER_KEY =
         new StringBuilder("DelegateRepaintManagerKey");
+
+    private static Color disabledForeground;
+    private static Color acceleratorSelectionForeground;
+    private static Color acceleratorForeground;
 
     /**
       * Registers delegate RepaintManager for {@code JComponent}.
@@ -111,6 +124,128 @@ public class SwingUtilities3 {
     public static boolean isVsyncRequested(Container rootContainer) {
         assert (rootContainer instanceof Applet) || (rootContainer instanceof Window);
         return Boolean.TRUE == vsyncedMap.get(rootContainer);
+    }
+
+    public static void applyInsets(Rectangle rect, Insets insets) {
+        if (insets != null) {
+            rect.x += insets.left;
+            rect.y += insets.top;
+            rect.width -= (insets.right + rect.x);
+            rect.height -= (insets.bottom + rect.y);
+        }
+    }
+
+    public static void paintCheckIcon(Graphics g, MenuItemLayoutHelper lh,
+                               MenuItemLayoutHelper.LayoutResult lr,
+                               Color holdc, Color foreground) {
+        if (lh.getCheckIcon() != null) {
+            ButtonModel model = lh.getMenuItem().getModel();
+            if (model.isArmed() || (lh.getMenuItem() instanceof JMenu
+                    && model.isSelected())) {
+                g.setColor(foreground);
+            } else {
+                g.setColor(holdc);
+            }
+            if (lh.useCheckAndArrow()) {
+                lh.getCheckIcon().paintIcon(lh.getMenuItem(), g,
+                        lr.getCheckRect().x, lr.getCheckRect().y);
+            }
+            g.setColor(holdc);
+        }
+    }
+
+    public static void paintIcon(Graphics g, MenuItemLayoutHelper lh,
+                          MenuItemLayoutHelper.LayoutResult lr, Color holdc) {
+        if (lh.getIcon() != null) {
+            Icon icon;
+            ButtonModel model = lh.getMenuItem().getModel();
+            if (!model.isEnabled()) {
+                icon = lh.getMenuItem().getDisabledIcon();
+            } else if (model.isPressed() && model.isArmed()) {
+                icon = lh.getMenuItem().getPressedIcon();
+                if (icon == null) {
+                    // Use default icon
+                    icon = lh.getMenuItem().getIcon();
+                }
+            } else {
+                icon = lh.getMenuItem().getIcon();
+            }
+
+            if (icon != null) {
+                icon.paintIcon(lh.getMenuItem(), g, lr.getIconRect().x,
+                        lr.getIconRect().y);
+                g.setColor(holdc);
+            }
+        }
+    }
+
+
+    public static void paintAccText(Graphics g, MenuItemLayoutHelper lh,
+                             MenuItemLayoutHelper.LayoutResult lr) {
+        if (!lh.getAccText().isEmpty()) {
+            ButtonModel model = lh.getMenuItem().getModel();
+            g.setFont(lh.getAccFontMetrics().getFont());
+            if (!model.isEnabled()) {
+
+                // paint the accText disabled
+                if (disabledForeground != null) {
+                    g.setColor(disabledForeground);
+                    SwingUtilities2.drawString(lh.getMenuItem(), g,
+                            lh.getAccText(), lr.getAccRect().x,
+                            lr.getAccRect().y + lh.getAccFontMetrics().getAscent());
+                } else {
+                    g.setColor(lh.getMenuItem().getBackground().brighter());
+                    SwingUtilities2.drawString(lh.getMenuItem(), g,
+                            lh.getAccText(), lr.getAccRect().x,
+                            lr.getAccRect().y + lh.getAccFontMetrics().getAscent());
+                    g.setColor(lh.getMenuItem().getBackground().darker());
+                    SwingUtilities2.drawString(lh.getMenuItem(), g,
+                            lh.getAccText(), lr.getAccRect().x - 1,
+                            lr.getAccRect().y + lh.getFontMetrics().getAscent() - 1);
+                }
+            } else {
+
+                // paint the accText normally
+                if (model.isArmed()
+                        || (lh.getMenuItem() instanceof JMenu
+                        && model.isSelected())) {
+                    g.setColor(acceleratorSelectionForeground);
+                } else {
+                    g.setColor(acceleratorForeground);
+                }
+                SwingUtilities2.drawString(lh.getMenuItem(), g, lh.getAccText(),
+                        lr.getAccRect().x, lr.getAccRect().y +
+                                lh.getAccFontMetrics().getAscent());
+            }
+        }
+    }
+
+    public static void setDisabledForeground(Color disabledFg) {
+        disabledForeground = disabledFg;
+    }
+
+    public static void setAcceleratorSelectionForeground(Color acceleratorSelectionFg) {
+        acceleratorForeground = acceleratorSelectionFg;
+    }
+
+    public static void setAcceleratorForeground(Color acceleratorFg) {
+        acceleratorForeground = acceleratorFg;
+    }
+
+    public static void paintArrowIcon(Graphics g, MenuItemLayoutHelper lh,
+                               MenuItemLayoutHelper.LayoutResult lr,
+                               Color foreground) {
+        if (lh.getArrowIcon() != null) {
+            ButtonModel model = lh.getMenuItem().getModel();
+            if (model.isArmed() || (lh.getMenuItem() instanceof JMenu
+                    && model.isSelected())) {
+                g.setColor(foreground);
+            }
+            if (lh.useCheckAndArrow()) {
+                lh.getArrowIcon().paintIcon(lh.getMenuItem(), g,
+                        lr.getArrowRect().x, lr.getArrowRect().y);
+            }
+        }
     }
 
     /**

--- a/jdk/src/share/classes/com/sun/java/swing/SwingUtilities3.java
+++ b/jdk/src/share/classes/com/sun/java/swing/SwingUtilities3.java
@@ -225,7 +225,7 @@ public class SwingUtilities3 {
     }
 
     public static void setAcceleratorSelectionForeground(Color acceleratorSelectionFg) {
-        acceleratorForeground = acceleratorSelectionFg;
+        acceleratorSelectionForeground = acceleratorSelectionFg;
     }
 
     public static void setAcceleratorForeground(Color acceleratorFg) {

--- a/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
+++ b/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsCheckBoxMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,16 @@
 
 package com.sun.java.swing.plaf.windows;
 
-import java.awt.*;
-import javax.swing.*;
-import javax.swing.plaf.*;
-import javax.swing.plaf.basic.*;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.Rectangle;
+
+import javax.swing.ButtonModel;
+import javax.swing.Icon;
+import javax.swing.JComponent;
+import javax.swing.JMenuItem;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicCheckBoxMenuItemUI;
 
 import com.sun.java.swing.plaf.windows.TMSchema.Part;
 import com.sun.java.swing.plaf.windows.TMSchema.State;
@@ -74,6 +80,24 @@ public class WindowsCheckBoxMenuItemUI extends BasicCheckBoxMenuItemUI {
         }
         super.paintBackground(g, menuItem, bgColor);
     }
+
+    /**
+     * Paint MenuItem.
+     */
+    protected void paintMenuItem(Graphics g, JComponent c,
+                                 Icon checkIcon, Icon arrowIcon,
+                                 Color background, Color foreground,
+                                 int defaultTextIconGap) {
+        if (WindowsMenuItemUI.isVistaPainting()) {
+            WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon,
+                    arrowIcon, background, foreground, defaultTextIconGap,
+                    menuItem, getPropertyPrefix());
+            return;
+        }
+        super.paintMenuItem(g, c, checkIcon, arrowIcon, background,
+                foreground, defaultTextIconGap);
+    }
+
     /**
      * Method which renders the text of the current menu item.
      * <p>

--- a/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
+++ b/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsIconFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -808,19 +808,18 @@ public class WindowsIconFactory implements Serializable
                         }
                         XPStyle xp = XPStyle.getXP();
                         if (xp != null) {
-                            Skin skin;
-                            skin =  xp.getSkin(c, backgroundPart);
-                            skin.paintSkin(g, x, y,
-                                getIconWidth(), getIconHeight(), backgroundState);
-                            if (icon == null) {
-                                skin = xp.getSkin(c, part);
+                            Skin skin = xp.getSkin(c, part);
+                            if (icon == null || icon.getIconHeight() <= 16) {
                                 skin.paintSkin(g, x + OFFSET, y + OFFSET, state);
+                            } else {
+                                skin.paintSkin(g, x + OFFSET, y + icon.getIconHeight() / 2, state);
                             }
                         }
                     }
                 }
                 if (icon != null) {
-                    icon.paintIcon(c, g, x + OFFSET, y + OFFSET);
+                    icon.paintIcon(c, g, x + VistaMenuItemCheckIconFactory.getIconWidth(),
+                                   y + OFFSET);
                 }
             }
             private static WindowsMenuItemUIAccessor getAccessor(

--- a/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
+++ b/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsMenuUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2007, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,6 +122,25 @@ public class WindowsMenuUI extends BasicMenuUI {
         Object obj      = UIManager.get("MenuBar.rolloverEnabled");
         hotTrackingOn = (obj instanceof Boolean) ? (Boolean)obj : true;
     }
+
+    /**
+     * Paint MenuItem.
+     */
+    protected void paintMenuItem(Graphics g, JComponent c,
+                              Icon checkIcon, Icon arrowIcon,
+                              Color background, Color foreground,
+                              int defaultTextIconGap) {
+        if (WindowsMenuItemUI.isVistaPainting()) {
+            WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon, arrowIcon,
+                                            background, foreground,
+                                            defaultTextIconGap, menuItem,
+                                            getPropertyPrefix());
+            return;
+        }
+        super.paintMenuItem(g, c, checkIcon, arrowIcon, background,
+                                   foreground, defaultTextIconGap);
+    }
+
 
     /**
      * Draws the background of the menu.

--- a/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
+++ b/jdk/src/share/classes/com/sun/java/swing/plaf/windows/WindowsRadioButtonMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,6 +72,23 @@ public class WindowsRadioButtonMenuItemUI extends BasicRadioButtonMenuItemUI {
             return;
         }
         super.paintBackground(g, menuItem, bgColor);
+    }
+
+    /**
+     * Paint MenuItem.
+     */
+    protected void paintMenuItem(Graphics g, JComponent c,
+                                 Icon checkIcon, Icon arrowIcon,
+                                 Color background, Color foreground,
+                                 int defaultTextIconGap) {
+        if (WindowsMenuItemUI.isVistaPainting()) {
+            WindowsMenuItemUI.paintMenuItem(accessor, g, c, checkIcon,
+                    arrowIcon, background, foreground, defaultTextIconGap,
+                    menuItem, getPropertyPrefix());
+            return;
+        }
+        super.paintMenuItem(g, c, checkIcon, arrowIcon, background,
+                foreground, defaultTextIconGap);
     }
 
     /**

--- a/jdk/src/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
+++ b/jdk/src/share/classes/javax/swing/plaf/basic/BasicMenuItemUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import javax.swing.event.*;
 import javax.swing.plaf.*;
 import javax.swing.text.View;
 
+import com.sun.java.swing.SwingUtilities3;
 import sun.swing.*;
 
 /**
@@ -561,84 +562,22 @@ public class BasicMenuItemUI extends MenuItemUI
 
     private void paintIcon(Graphics g, MenuItemLayoutHelper lh,
                            MenuItemLayoutHelper.LayoutResult lr, Color holdc) {
-        if (lh.getIcon() != null) {
-            Icon icon;
-            ButtonModel model = lh.getMenuItem().getModel();
-            if (!model.isEnabled()) {
-                icon = lh.getMenuItem().getDisabledIcon();
-            } else if (model.isPressed() && model.isArmed()) {
-                icon = lh.getMenuItem().getPressedIcon();
-                if (icon == null) {
-                    // Use default icon
-                    icon = lh.getMenuItem().getIcon();
-                }
-            } else {
-                icon = lh.getMenuItem().getIcon();
-            }
-
-            if (icon != null) {
-                icon.paintIcon(lh.getMenuItem(), g, lr.getIconRect().x,
-                        lr.getIconRect().y);
-                g.setColor(holdc);
-            }
-        }
+        SwingUtilities3.paintIcon(g, lh, lr, holdc);
     }
 
     private void paintCheckIcon(Graphics g, MenuItemLayoutHelper lh,
                                 MenuItemLayoutHelper.LayoutResult lr,
                                 Color holdc, Color foreground) {
-        if (lh.getCheckIcon() != null) {
-            ButtonModel model = lh.getMenuItem().getModel();
-            if (model.isArmed() || (lh.getMenuItem() instanceof JMenu
-                    && model.isSelected())) {
-                g.setColor(foreground);
-            } else {
-                g.setColor(holdc);
-            }
-            if (lh.useCheckAndArrow()) {
-                lh.getCheckIcon().paintIcon(lh.getMenuItem(), g,
-                        lr.getCheckRect().x, lr.getCheckRect().y);
-            }
-            g.setColor(holdc);
-        }
+        SwingUtilities3.paintCheckIcon(g, lh, lr, holdc, foreground);
     }
 
     private void paintAccText(Graphics g, MenuItemLayoutHelper lh,
                               MenuItemLayoutHelper.LayoutResult lr) {
-        if (!lh.getAccText().equals("")) {
-            ButtonModel model = lh.getMenuItem().getModel();
-            g.setFont(lh.getAccFontMetrics().getFont());
-            if (!model.isEnabled()) {
-                // *** paint the accText disabled
-                if (disabledForeground != null) {
-                    g.setColor(disabledForeground);
-                    SwingUtilities2.drawString(lh.getMenuItem(), g,
-                        lh.getAccText(), lr.getAccRect().x,
-                        lr.getAccRect().y + lh.getAccFontMetrics().getAscent());
-                } else {
-                    g.setColor(lh.getMenuItem().getBackground().brighter());
-                    SwingUtilities2.drawString(lh.getMenuItem(), g,
-                        lh.getAccText(), lr.getAccRect().x,
-                        lr.getAccRect().y + lh.getAccFontMetrics().getAscent());
-                    g.setColor(lh.getMenuItem().getBackground().darker());
-                    SwingUtilities2.drawString(lh.getMenuItem(), g,
-                        lh.getAccText(), lr.getAccRect().x - 1,
-                        lr.getAccRect().y + lh.getFontMetrics().getAscent() - 1);
-                }
-            } else {
-                // *** paint the accText normally
-                if (model.isArmed()
-                        || (lh.getMenuItem() instanceof JMenu
-                        && model.isSelected())) {
-                    g.setColor(acceleratorSelectionForeground);
-                } else {
-                    g.setColor(acceleratorForeground);
-                }
-                SwingUtilities2.drawString(lh.getMenuItem(), g, lh.getAccText(),
-                        lr.getAccRect().x, lr.getAccRect().y +
-                        lh.getAccFontMetrics().getAscent());
-            }
-        }
+        SwingUtilities3.setDisabledForeground(disabledForeground);
+        SwingUtilities3.setAcceleratorSelectionForeground(
+                        acceleratorSelectionForeground);
+        SwingUtilities3.setAcceleratorForeground(acceleratorForeground);
+        SwingUtilities3.paintAccText(g, lh, lr);
     }
 
     private void paintText(Graphics g, MenuItemLayoutHelper lh,
@@ -657,26 +596,11 @@ public class BasicMenuItemUI extends MenuItemUI
     private void paintArrowIcon(Graphics g, MenuItemLayoutHelper lh,
                                 MenuItemLayoutHelper.LayoutResult lr,
                                 Color foreground) {
-        if (lh.getArrowIcon() != null) {
-            ButtonModel model = lh.getMenuItem().getModel();
-            if (model.isArmed() || (lh.getMenuItem() instanceof JMenu
-                                && model.isSelected())) {
-                g.setColor(foreground);
-            }
-            if (lh.useCheckAndArrow()) {
-                lh.getArrowIcon().paintIcon(lh.getMenuItem(), g,
-                        lr.getArrowRect().x, lr.getArrowRect().y);
-            }
-        }
+        SwingUtilities3.paintArrowIcon(g, lh, lr, foreground);
     }
 
     private void applyInsets(Rectangle rect, Insets insets) {
-        if(insets != null) {
-            rect.x += insets.left;
-            rect.y += insets.top;
-            rect.width -= (insets.right + rect.x);
-            rect.height -= (insets.bottom + rect.y);
-        }
+        SwingUtilities3.applyInsets(rect, insets);
     }
 
     /**

--- a/jdk/test/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java
+++ b/jdk/test/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8348760
+ * @summary Verify if RadioButtonMenuItem bullet and
+ *          JCheckboxMenuItem checkmark is shown if
+ *          JRadioButtonMenuItem and JCheckboxMenuItem
+ *          is rendered with ImageIcon in WindowsLookAndFeel
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestRadioAndCheckMenuItemWithIcon
+ */
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import java.awt.image.BufferedImage;
+
+import javax.swing.AbstractButton;
+import javax.swing.ButtonGroup;
+import javax.swing.ImageIcon;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.KeyStroke;
+import javax.swing.UIManager;
+
+public class TestRadioAndCheckMenuItemWithIcon {
+
+    private static final String INSTRUCTIONS =
+         "A top level Menu will be shown.\n"
+         + "\n"
+         + "Clicking on the Menu will show a\n"
+         + "JRadioButtonMenuItem group with 3 radiobutton menuitems\n"
+         + "and a JCheckBoxMenuItem group with 3 checkbox menuitems.\n"
+         + "\n"
+         + "First radiobutton menuitem is selected with imageicon of a red square.\n"
+         + "Second radiobutton menuitem is unselected with imageicon.\n"
+         + "Third radiobutton menuItem is unselected without imageicon.\n"
+         + "\n"
+         + "First checkbox menuitem is selected with imageicon.\n"
+         + "Second checkbox menuitem is unselected with imageicon.\n"
+         + "Third checkbox menuItem is unselected without imageicon.\n"
+         + "\n"
+         + "Verify that for first JRadioButtonMenuItem with imageicon,\n"
+         + "a bullet is shown alongside the imageicon and\n"
+         + "for first JCheckBoxMenuItem with imageicon\n"
+         + "a checkmark is shown alongside the imageicon.\n"
+         + "\n"
+         + "If bullet and checkmark is shown, test passes else fails.";
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+        PassFailJFrame.builder()
+                .title("JRadioButtonMenuItem Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(60)
+                .testUI(TestRadioAndCheckMenuItemWithIcon::doTest)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFrame doTest() {
+        BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        Graphics g = img.getGraphics();
+        g.setColor(Color.red);
+        g.fillRect(0, 0, img.getWidth(), img.getHeight());
+        g.dispose();
+
+        BufferedImage img2 = new BufferedImage(64, 64, BufferedImage.TYPE_INT_ARGB);
+        Graphics g2 = img2.getGraphics();
+        g2.setColor(Color.red);
+        g2.fillRect(0, 0, img2.getWidth(), img2.getHeight());
+        g2.dispose();
+
+        JFrame frame = new JFrame("RadioButtonWithImageIcon");
+        ImageIcon imageIcon1 = new ImageIcon(img);
+        ImageIcon imageIcon2 = new ImageIcon(img2);
+        AbstractButton button1;
+        JRadioButtonMenuItem m1 = new JRadioButtonMenuItem("JRadioButtonMenuItem 1",
+                imageIcon1);
+        m1.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F4, ActionEvent.ALT_MASK|ActionEvent.CTRL_MASK|ActionEvent.SHIFT_MASK));
+        button1 = m1;
+        button1.setSelected(true);
+        AbstractButton button2 = new JRadioButtonMenuItem("JRadioButtonMenuItem 2", imageIcon2);
+        AbstractButton button3 = new JRadioButtonMenuItem("JRadioButtonMenuItem 3");
+
+        ButtonGroup buttonGroup = new ButtonGroup();
+        buttonGroup.add(button1);
+        buttonGroup.add(button2);
+        buttonGroup.add(button3);
+
+        AbstractButton check1 = new JCheckBoxMenuItem("JCheckBoxMenuItem 1",
+                imageIcon1);
+        check1.setSelected(true);
+        AbstractButton check2 = new JCheckBoxMenuItem("JCheckBoxMenuItem 2", imageIcon1);
+        JCheckBoxMenuItem c3;
+        AbstractButton check3 = c3 = new JCheckBoxMenuItem("JCheckBoxMenuItem 3");
+        c3.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F5, ActionEvent.ALT_MASK|ActionEvent.CTRL_MASK|ActionEvent.SHIFT_MASK));
+
+        JMenu topLevel = new JMenu("Menu");
+
+        topLevel.add(button1);
+        topLevel.add(button2);
+        topLevel.add(button3);
+
+        topLevel.addSeparator();
+
+        topLevel.add(check1);
+        topLevel.add(check2);
+        topLevel.add(check3);
+
+        AbstractButton menuitem1 = new JMenuItem("MenuItem1");
+        AbstractButton menuitem2 = new JMenuItem("MenuItem2", imageIcon1);
+        topLevel.addSeparator();
+        topLevel.add(menuitem1);
+        topLevel.add(menuitem2);
+
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.add(topLevel);
+
+        frame.setJMenuBar(menuBar);
+        frame.setSize(300, 300);
+        return frame;
+
+    }
+}

--- a/jdk/test/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java
+++ b/jdk/test/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/*
+ /*
  * @test
  * @bug 8348760
  * @summary Verify if RadioButtonMenuItem bullet and
@@ -29,20 +29,25 @@
  *          JRadioButtonMenuItem and JCheckboxMenuItem
  *          is rendered with ImageIcon in WindowsLookAndFeel
  * @requires (os.family == "windows")
- * @library /java/awt/regtesthelpers
- * @build PassFailJFrame
  * @run main/manual TestRadioAndCheckMenuItemWithIcon
  */
-
+import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.FlowLayout;
 import java.awt.Graphics;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.awt.image.BufferedImage;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.ImageIcon;
+import javax.swing.JButton;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JFrame;
 import javax.swing.JMenu;
@@ -50,45 +55,65 @@ import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 
 public class TestRadioAndCheckMenuItemWithIcon {
 
     private static final String INSTRUCTIONS =
-         "A top level Menu will be shown.\n"
-         + "\n"
-         + "Clicking on the Menu will show a\n"
-         + "JRadioButtonMenuItem group with 3 radiobutton menuitems\n"
-         + "and a JCheckBoxMenuItem group with 3 checkbox menuitems.\n"
-         + "\n"
-         + "First radiobutton menuitem is selected with imageicon of a red square.\n"
-         + "Second radiobutton menuitem is unselected with imageicon.\n"
-         + "Third radiobutton menuItem is unselected without imageicon.\n"
-         + "\n"
-         + "First checkbox menuitem is selected with imageicon.\n"
-         + "Second checkbox menuitem is unselected with imageicon.\n"
-         + "Third checkbox menuItem is unselected without imageicon.\n"
-         + "\n"
-         + "Verify that for first JRadioButtonMenuItem with imageicon,\n"
-         + "a bullet is shown alongside the imageicon and\n"
-         + "for first JCheckBoxMenuItem with imageicon\n"
-         + "a checkmark is shown alongside the imageicon.\n"
-         + "\n"
-         + "If bullet and checkmark is shown, test passes else fails.";
+            "Clicking on the Menu above will show a\n"
+            + "JRadioButtonMenuItem group with 3 radiobutton menuitems\n"
+            + "and a JCheckBoxMenuItem group with 3 checkbox menuitems.\n"
+            + "\n"
+            + "First radiobutton menuitem is selected with imageicon of a red square.\n"
+            + "Second radiobutton menuitem is unselected with imageicon.\n"
+            + "Third radiobutton menuItem is unselected without imageicon.\n"
+            + "\n"
+            + "First checkbox menuitem is selected with imageicon.\n"
+            + "Second checkbox menuitem is unselected with imageicon.\n"
+            + "Third checkbox menuItem is unselected without imageicon.\n"
+            + "\n"
+            + "Verify that for first JRadioButtonMenuItem with imageicon,\n"
+            + "a bullet is shown alongside the imageicon and\n"
+            + "for first JCheckBoxMenuItem with imageicon\n"
+            + "a checkmark is shown alongside the imageicon.\n"
+            + "\n"
+            + "If bullet and checkmark is shown, test passes else fails.";
+
+    private static final LinkedBlockingQueue<Boolean> resultQueue = new LinkedBlockingQueue<Boolean>(1);
+
+    private static void endTest(boolean result) {
+        SwingUtilities.invokeLater(
+                new Runnable() {
+                    public void run() {
+                        try {
+                            resultQueue.put(result);
+                        } catch (Exception ignored) {
+                        }
+                    }
+                });
+    }
 
     public static void main(String[] args) throws Exception {
         UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-        PassFailJFrame.builder()
-                .title("JRadioButtonMenuItem Instructions")
-                .instructions(INSTRUCTIONS)
-                .columns(60)
-                .testUI(TestRadioAndCheckMenuItemWithIcon::doTest)
-                .build()
-                .awaitAndCheck();
+
+        SwingUtilities.invokeLater(new Runnable() {
+            public void run() {
+                TestRadioAndCheckMenuItemWithIcon.doTest();
+            }
+        });
+
+        Boolean testPasses = resultQueue.take();
+
+        if (!testPasses) {
+            throw new Exception("Test failed!");
+        }
     }
 
-    public static JFrame doTest() {
+    public static void doTest() {
         BufferedImage img = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
         Graphics g = img.getGraphics();
         g.setColor(Color.red);
@@ -107,7 +132,7 @@ public class TestRadioAndCheckMenuItemWithIcon {
         AbstractButton button1;
         JRadioButtonMenuItem m1 = new JRadioButtonMenuItem("JRadioButtonMenuItem 1",
                 imageIcon1);
-        m1.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F4, ActionEvent.ALT_MASK|ActionEvent.CTRL_MASK|ActionEvent.SHIFT_MASK));
+        m1.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F4, ActionEvent.ALT_MASK | ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK));
         button1 = m1;
         button1.setSelected(true);
         AbstractButton button2 = new JRadioButtonMenuItem("JRadioButtonMenuItem 2", imageIcon2);
@@ -124,7 +149,7 @@ public class TestRadioAndCheckMenuItemWithIcon {
         AbstractButton check2 = new JCheckBoxMenuItem("JCheckBoxMenuItem 2", imageIcon1);
         JCheckBoxMenuItem c3;
         AbstractButton check3 = c3 = new JCheckBoxMenuItem("JCheckBoxMenuItem 3");
-        c3.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F5, ActionEvent.ALT_MASK|ActionEvent.CTRL_MASK|ActionEvent.SHIFT_MASK));
+        c3.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F5, ActionEvent.ALT_MASK | ActionEvent.CTRL_MASK | ActionEvent.SHIFT_MASK));
 
         JMenu topLevel = new JMenu("Menu");
 
@@ -148,8 +173,56 @@ public class TestRadioAndCheckMenuItemWithIcon {
         menuBar.add(topLevel);
 
         frame.setJMenuBar(menuBar);
-        frame.setSize(300, 300);
-        return frame;
 
+        JTextArea instructions = new JTextArea();
+        instructions.setText(INSTRUCTIONS);
+        instructions.setEditable(false);
+        instructions.setColumns(80);
+        instructions.setRows(24);
+
+        JScrollPane scrInstructions = new JScrollPane(instructions);
+        frame.getContentPane().setLayout(new BorderLayout());
+
+        frame.getContentPane().add(scrInstructions, BorderLayout.CENTER);
+
+        JPanel yesno = new JPanel();
+        yesno.setLayout(new GridLayout(1, 2, 40, 40));
+
+        JButton yes = new JButton("Passes");
+        JButton no = new JButton("Fails");
+        yesno.add(yes);
+        yesno.add(no);
+
+        yes.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                frame.dispose();
+                endTest(true);
+            }
+        });
+
+        no.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                frame.dispose();
+                endTest(false);
+            }
+        });
+
+        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+        frame.addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosed(WindowEvent e) {
+                frame.dispose();
+                endTest(false);
+}
+        });
+
+        frame.getContentPane().add(yesno, BorderLayout.SOUTH);
+
+        frame.pack();
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
     }
 }
+


### PR DESCRIPTION
Backport of [JDK-8348760](https://bugs.openjdk.org/browse/JDK-8348760) (P1 - CPU25_10-critical-approved) and [JDK-8365375](https://bugs.openjdk.org/browse/JDK-8365375) from 17 (11 is still pending approval) that properly renders JRadioButtonMenuItems with ImageIcons in the Windows Look and Feel on Windows 11.

The issue is reproducible in OpenJDK 8 with the Windows Look and Feel on Windows 11.

- Passes tier1 tests
- Passes the new (manual) test on Windows 11/x86_64 (24H2/26100.6584)

The backport is separated in three commits:

- Backport of JDK-8348760
- Modify the new test `jdk/test/javax/swing/JMenuItem/TestRadioAndCheckMenuItemWithIcon.java` to not depend on `@library /java/awt/regtesthelpers` / `@PassFailJFrame`, since `PassFailJFrame` is not available in JDK8.
- Backport of JDK-8365375



NOTE: Related issues [JDK-8365389](https://bugs.openjdk.org/browse/JDK-8365389) and [JDK-8365625](https://bugs.openjdk.org/browse/JDK-8365625) (all P3) will also need to be backported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8365375](https://bugs.openjdk.org/browse/JDK-8365375) needs maintainer approval
- [ ] [JDK-8348760](https://bugs.openjdk.org/browse/JDK-8348760) needs maintainer approval

### Issues
 * [JDK-8348760](https://bugs.openjdk.org/browse/JDK-8348760): RadioButton is not shown if JRadioButtonMenuItem is rendered with ImageIcon in WindowsLookAndFeel (**Bug** - P1)
 * [JDK-8365375](https://bugs.openjdk.org/browse/JDK-8365375): Method SU3.setAcceleratorSelectionForeground assigns to acceleratorForeground (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/77.diff">https://git.openjdk.org/jdk8u/pull/77.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/77#issuecomment-3322949343)
</details>
