### PR TITLE
8379256: Update GIFlib to 6.1.1

### DIFF
--- a/THIRD_PARTY_README
+++ b/THIRD_PARTY_README
@@ -2377,12 +2377,12 @@ licenses.
 
 -------------------------------------------------------------------------------
 
-%% This notice is provided with respect to GIFLIB 5.2.2 & libungif 4.1.3,
+%% This notice is provided with respect to GIFLIB 6.1.1 & libungif 4.1.3,
 which may be included with JRE 8, JDK 8, and OpenJDK 8.
 
 --- begin of LICENSE ---
 
-The GIFLIB distribution is Copyright (c) 1997  Eric S. Raymond
+= MIT LICENSE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -2402,7 +2402,18 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
-tree/README
+---------------------------------
+The below applies to the following file(s):
+giflib/dgif_lib.c
+giflib/gifalloc.c
+giflib/gif_err.c
+giflib/openbsd-reallocarray.c
+
+Copyright (C) 1989 Gershon Elber
+Copyright (C) 2008 Otto Moerbeek <otto@drijf.net>
+Copyright (C) Eric S. Raymond <esr@thyrsus.com>
+
+SPDX-License-Identifier: MIT
 
 == Authors ==
 
@@ -2415,15 +2426,6 @@ former maintainer
 
 Eric Raymond <esr[AT]snark.thyrsus.com>
 current as well as long time former maintainer of giflib code
-
-There have been many other contributors; see the attributions in the
-version-control history to learn more.
-
-
-tree/openbsd-reallocarray.c
-
-Copyright (C) 2008 Otto Moerbeek <otto@drijf.net>
-SPDX-License-Identifier: MIT
 
 --- end of LICENSE ---
 

--- a/jdk/src/share/native/sun/awt/giflib/COPYING
+++ b/jdk/src/share/native/sun/awt/giflib/COPYING
@@ -1,4 +1,4 @@
-The GIFLIB distribution is Copyright (c) 1997  Eric S. Raymond
+= MIT LICENSE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/jdk/src/share/native/sun/awt/giflib/dgif_lib.c
+++ b/jdk/src/share/native/sun/awt/giflib/dgif_lib.c
@@ -30,9 +30,9 @@ The functions here and in egif_lib.c are partitioned carefully so that
 if you only require one of read and write capability, only one of these
 two modules will be linked.  Preserve this property!
 
-SPDX-License-Identifier: MIT
-
 *****************************************************************************/
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (C) Eric S. Raymond <esr@thyrsus.com>
 
 #include <fcntl.h>
 #include <limits.h>
@@ -55,11 +55,11 @@ SPDX-License-Identifier: MIT
 
 /* avoid extra function call in case we use fread (TVT) */
 static int InternalRead(GifFileType *gif, GifByteType *buf, int len) {
-    // fprintf(stderr, "### Read: %d\n", len);
-    return (((GifFilePrivateType *)gif->Private)->Read
-                ? ((GifFilePrivateType *)gif->Private)->Read(gif, buf, len)
-                : fread(buf, 1, len,
-                        ((GifFilePrivateType *)gif->Private)->File));
+        // fprintf(stderr, "### Read: %d\n", len);
+        return (((GifFilePrivateType *)gif->Private)->Read
+                    ? ((GifFilePrivateType *)gif->Private)->Read(gif, buf, len)
+                    : fread(buf, 1, len,
+                            ((GifFilePrivateType *)gif->Private)->File));
 }
 
 static int DGifGetWord(GifFileType *GifFile, GifWord *Word);
@@ -78,18 +78,18 @@ static int DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf,
  info record.
 ******************************************************************************/
 GifFileType *DGifOpenFileName(const char *FileName, int *Error) {
-    int FileHandle;
-    GifFileType *GifFile;
+        int FileHandle;
+        GifFileType *GifFile;
 
-    if ((FileHandle = open(FileName, O_RDONLY)) == -1) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_OPEN_FAILED;
+        if ((FileHandle = open(FileName, O_RDONLY)) == -1) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_OPEN_FAILED;
+                }
+                return NULL;
         }
-        return NULL;
-    }
 
-    GifFile = DGifOpenFileHandle(FileHandle, Error);
-    return GifFile;
+        GifFile = DGifOpenFileHandle(FileHandle, Error);
+        return GifFile;
 }
 
 /******************************************************************************
@@ -98,171 +98,171 @@ GifFileType *DGifOpenFileName(const char *FileName, int *Error) {
  info record.
 ******************************************************************************/
 GifFileType *DGifOpenFileHandle(int FileHandle, int *Error) {
-    char Buf[GIF_STAMP_LEN + 1];
-    GifFileType *GifFile;
-    GifFilePrivateType *Private;
-    FILE *f;
+        char Buf[GIF_STAMP_LEN + 1];
+        GifFileType *GifFile;
+        GifFilePrivateType *Private;
+        FILE *f;
 
-    GifFile = (GifFileType *)malloc(sizeof(GifFileType));
-    if (GifFile == NULL) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        GifFile = (GifFileType *)malloc(sizeof(GifFileType));
+        if (GifFile == NULL) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                }
+                (void)close(FileHandle);
+                return NULL;
         }
-        (void)close(FileHandle);
-        return NULL;
-    }
 
-    /*@i1@*/ memset(GifFile, '\0', sizeof(GifFileType));
+        /*@i1@*/ memset(GifFile, '\0', sizeof(GifFileType));
 
-    /* Belt and suspenders, in case the null pointer isn't zero */
-    GifFile->SavedImages = NULL;
-    GifFile->SColorMap = NULL;
+        /* Belt and suspenders, in case the null pointer isn't zero */
+        GifFile->SavedImages = NULL;
+        GifFile->SColorMap = NULL;
 
-    Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
-    if (Private == NULL) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
+        if (Private == NULL) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                }
+                (void)close(FileHandle);
+                free((char *)GifFile);
+                return NULL;
         }
-        (void)close(FileHandle);
-        free((char *)GifFile);
-        return NULL;
-    }
 
-    /*@i1@*/ memset(Private, '\0', sizeof(GifFilePrivateType));
+        /*@i1@*/ memset(Private, '\0', sizeof(GifFilePrivateType));
 
 #ifdef _WIN32
-    _setmode(FileHandle, O_BINARY); /* Make sure it is in binary mode. */
+        _setmode(FileHandle, O_BINARY); /* Make sure it is in binary mode. */
 #endif                                  /* _WIN32 */
 
-    f = fdopen(FileHandle, "rb"); /* Make it into a stream: */
+        f = fdopen(FileHandle, "rb"); /* Make it into a stream: */
 
-    /*@-mustfreeonly@*/
-    GifFile->Private = (void *)Private;
-    Private->FileHandle = FileHandle;
-    Private->File = f;
-    Private->FileState = FILE_STATE_READ;
-    Private->Read = NULL;     /* don't use alternate input method (TVT) */
-    GifFile->UserData = NULL; /* TVT */
-    /*@=mustfreeonly@*/
+        /*@-mustfreeonly@*/
+        GifFile->Private = (void *)Private;
+        Private->FileHandle = FileHandle;
+        Private->File = f;
+        Private->FileState = FILE_STATE_READ;
+        Private->Read = NULL;     /* don't use alternate input method (TVT) */
+        GifFile->UserData = NULL; /* TVT */
+        /*@=mustfreeonly@*/
 
-    /* Let's see if this is a GIF file: */
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) !=
-        GIF_STAMP_LEN) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_READ_FAILED;
+        /* Let's see if this is a GIF file: */
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) !=
+            GIF_STAMP_LEN) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_READ_FAILED;
+                }
+                (void)fclose(f);
+                free((char *)Private);
+                free((char *)GifFile);
+                return NULL;
         }
-        (void)fclose(f);
-        free((char *)Private);
-        free((char *)GifFile);
-        return NULL;
-    }
 
-    /* Check for GIF prefix at start of file */
-    Buf[GIF_STAMP_LEN] = 0;
-    if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_GIF_FILE;
+        /* Check for GIF prefix at start of file */
+        Buf[GIF_STAMP_LEN] = 0;
+        if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_GIF_FILE;
+                }
+                (void)fclose(f);
+                free((char *)Private);
+                free((char *)GifFile);
+                return NULL;
         }
-        (void)fclose(f);
-        free((char *)Private);
-        free((char *)GifFile);
-        return NULL;
-    }
 
-    if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
-        (void)fclose(f);
-        free((char *)Private);
-        free((char *)GifFile);
-        return NULL;
-    }
+        if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
+                (void)fclose(f);
+                free((char *)Private);
+                free((char *)GifFile);
+                return NULL;
+        }
 
-    GifFile->Error = 0;
+        GifFile->Error = 0;
 
-    /* What version of GIF? */
-    Private->gif89 = (Buf[GIF_VERSION_POS + 1] == '9');
+        /* What version of GIF? */
+        Private->gif89 = (Buf[GIF_VERSION_POS + 1] == '9');
 
-    return GifFile;
+        return GifFile;
 }
 
 /******************************************************************************
  GifFileType constructor with user supplied input function (TVT)
 ******************************************************************************/
 GifFileType *DGifOpen(void *userData, InputFunc readFunc, int *Error) {
-    char Buf[GIF_STAMP_LEN + 1];
-    GifFileType *GifFile;
-    GifFilePrivateType *Private;
+        char Buf[GIF_STAMP_LEN + 1];
+        GifFileType *GifFile;
+        GifFilePrivateType *Private;
 
-    GifFile = (GifFileType *)malloc(sizeof(GifFileType));
-    if (GifFile == NULL) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        GifFile = (GifFileType *)malloc(sizeof(GifFileType));
+        if (GifFile == NULL) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                }
+                return NULL;
         }
-        return NULL;
-    }
 
-    memset(GifFile, '\0', sizeof(GifFileType));
+        memset(GifFile, '\0', sizeof(GifFileType));
 
-    /* Belt and suspenders, in case the null pointer isn't zero */
-    GifFile->SavedImages = NULL;
-    GifFile->SColorMap = NULL;
+        /* Belt and suspenders, in case the null pointer isn't zero */
+        GifFile->SavedImages = NULL;
+        GifFile->SColorMap = NULL;
 
-    Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
-    if (!Private) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+        Private = (GifFilePrivateType *)calloc(1, sizeof(GifFilePrivateType));
+        if (!Private) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                }
+                free((char *)GifFile);
+                return NULL;
         }
-        free((char *)GifFile);
-        return NULL;
-    }
-    /*@i1@*/ memset(Private, '\0', sizeof(GifFilePrivateType));
+        /*@i1@*/ memset(Private, '\0', sizeof(GifFilePrivateType));
 
-    GifFile->Private = (void *)Private;
-    Private->FileHandle = 0;
-    Private->File = NULL;
-    Private->FileState = FILE_STATE_READ;
+        GifFile->Private = (void *)Private;
+        Private->FileHandle = 0;
+        Private->File = NULL;
+        Private->FileState = FILE_STATE_READ;
 
-    Private->Read = readFunc;     /* TVT */
-    GifFile->UserData = userData; /* TVT */
+        Private->Read = readFunc;     /* TVT */
+        GifFile->UserData = userData; /* TVT */
 
-    /* Lets see if this is a GIF file: */
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) !=
-        GIF_STAMP_LEN) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_READ_FAILED;
+        /* Lets see if this is a GIF file: */
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, (unsigned char *)Buf, GIF_STAMP_LEN) !=
+            GIF_STAMP_LEN) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_READ_FAILED;
+                }
+                free((char *)Private);
+                free((char *)GifFile);
+                return NULL;
         }
-        free((char *)Private);
-        free((char *)GifFile);
-        return NULL;
-    }
 
-    /* Check for GIF prefix at start of file */
-    Buf[GIF_STAMP_LEN] = '\0';
-    if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NOT_GIF_FILE;
+        /* Check for GIF prefix at start of file */
+        Buf[GIF_STAMP_LEN] = '\0';
+        if (strncmp(GIF_STAMP, Buf, GIF_VERSION_POS) != 0) {
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NOT_GIF_FILE;
+                }
+                free((char *)Private);
+                free((char *)GifFile);
+                return NULL;
         }
-        free((char *)Private);
-        free((char *)GifFile);
-        return NULL;
-    }
 
-    if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
-        free((char *)Private);
-        free((char *)GifFile);
-        if (Error != NULL) {
-            *Error = D_GIF_ERR_NO_SCRN_DSCR;
+        if (DGifGetScreenDesc(GifFile) == GIF_ERROR) {
+                free((char *)Private);
+                free((char *)GifFile);
+                if (Error != NULL) {
+                        *Error = D_GIF_ERR_NO_SCRN_DSCR;
+                }
+                return NULL;
         }
-        return NULL;
-    }
 
-    GifFile->Error = 0;
+        GifFile->Error = 0;
 
-    /* What version of GIF? */
-    Private->gif89 = (Buf[GIF_VERSION_POS + 1] == '9');
+        /* What version of GIF? */
+        Private->gif89 = (Buf[GIF_VERSION_POS + 1] == '9');
 
-    return GifFile;
+        return GifFile;
 }
 
 /******************************************************************************
@@ -270,180 +270,180 @@ GifFileType *DGifOpen(void *userData, InputFunc readFunc, int *Error) {
  this routine is called automatically from DGif file open routines.
 ******************************************************************************/
 int DGifGetScreenDesc(GifFileType *GifFile) {
-    int BitsPerPixel;
-    bool SortFlag;
-    GifByteType Buf[3];
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        int BitsPerPixel;
+        bool SortFlag;
+        GifByteType Buf[3];
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-
-    /* Put the screen descriptor into the file: */
-    if (DGifGetWord(GifFile, &GifFile->SWidth) == GIF_ERROR ||
-        DGifGetWord(GifFile, &GifFile->SHeight) == GIF_ERROR) {
-        return GIF_ERROR;
-    }
-
-    if (InternalRead(GifFile, Buf, 3) != 3) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        GifFreeMapObject(GifFile->SColorMap);
-        GifFile->SColorMap = NULL;
-        return GIF_ERROR;
-    }
-    GifFile->SColorResolution = (((Buf[0] & 0x70) + 1) >> 4) + 1;
-    SortFlag = (Buf[0] & 0x08) != 0;
-    BitsPerPixel = (Buf[0] & 0x07) + 1;
-    GifFile->SBackGroundColor = Buf[1];
-    GifFile->AspectByte = Buf[2];
-    if (Buf[0] & 0x80) { /* Do we have global color map? */
-        int i;
-
-        GifFile->SColorMap = GifMakeMapObject(1 << BitsPerPixel, NULL);
-        if (GifFile->SColorMap == NULL) {
-            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
-            return GIF_ERROR;
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
         }
 
-        /* Get the global color map: */
-        GifFile->SColorMap->SortFlag = SortFlag;
-        for (i = 0; i < GifFile->SColorMap->ColorCount; i++) {
-            /* coverity[check_return] */
-            if (InternalRead(GifFile, Buf, 3) != 3) {
+        /* Put the screen descriptor into the file: */
+        if (DGifGetWord(GifFile, &GifFile->SWidth) == GIF_ERROR ||
+            DGifGetWord(GifFile, &GifFile->SHeight) == GIF_ERROR) {
+                return GIF_ERROR;
+        }
+
+        if (InternalRead(GifFile, Buf, 3) != 3) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
                 GifFreeMapObject(GifFile->SColorMap);
                 GifFile->SColorMap = NULL;
-                GifFile->Error = D_GIF_ERR_READ_FAILED;
                 return GIF_ERROR;
-            }
-            GifFile->SColorMap->Colors[i].Red = Buf[0];
-            GifFile->SColorMap->Colors[i].Green = Buf[1];
-            GifFile->SColorMap->Colors[i].Blue = Buf[2];
         }
-    } else {
-        GifFile->SColorMap = NULL;
-    }
+        GifFile->SColorResolution = (((Buf[0] & 0x70) + 1) >> 4) + 1;
+        SortFlag = (Buf[0] & 0x08) != 0;
+        BitsPerPixel = (Buf[0] & 0x07) + 1;
+        GifFile->SBackGroundColor = Buf[1];
+        GifFile->AspectByte = Buf[2];
+        if (Buf[0] & 0x80) { /* Do we have global color map? */
+                int i;
 
-    /*
-     * No check here for whether the background color is in range for the
-     * screen color map.  Possibly there should be.
-     */
+                GifFile->SColorMap = GifMakeMapObject(1 << BitsPerPixel, NULL);
+                if (GifFile->SColorMap == NULL) {
+                        GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                        return GIF_ERROR;
+                }
 
-    return GIF_OK;
+                /* Get the global color map: */
+                GifFile->SColorMap->SortFlag = SortFlag;
+                for (i = 0; i < GifFile->SColorMap->ColorCount; i++) {
+                        /* coverity[check_return] */
+                        if (InternalRead(GifFile, Buf, 3) != 3) {
+                                GifFreeMapObject(GifFile->SColorMap);
+                                GifFile->SColorMap = NULL;
+                                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                                return GIF_ERROR;
+                        }
+                        GifFile->SColorMap->Colors[i].Red = Buf[0];
+                        GifFile->SColorMap->Colors[i].Green = Buf[1];
+                        GifFile->SColorMap->Colors[i].Blue = Buf[2];
+                }
+        } else {
+                GifFile->SColorMap = NULL;
+        }
+
+        /*
+         * No check here for whether the background color is in range for the
+         * screen color map.  Possibly there should be.
+         */
+
+        return GIF_OK;
 }
 
 const char *DGifGetGifVersion(GifFileType *GifFile) {
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (Private->gif89) {
-        return GIF89_STAMP;
-    } else {
-        return GIF87_STAMP;
-    }
+        if (Private->gif89) {
+                return GIF89_STAMP;
+        } else {
+                return GIF87_STAMP;
+        }
 }
 
 /******************************************************************************
  This routine should be called before any attempt to read an image.
 ******************************************************************************/
 int DGifGetRecordType(GifFileType *GifFile, GifRecordType *Type) {
-    GifByteType Buf;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType Buf;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
+        }
 
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, &Buf, 1) != 1) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR;
-    }
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, &Buf, 1) != 1) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
+        }
 
-    // fprintf(stderr, "### DGifGetRecordType: %02x\n", Buf);
-    switch (Buf) {
-    case DESCRIPTOR_INTRODUCER:
-        *Type = IMAGE_DESC_RECORD_TYPE;
-        break;
-    case EXTENSION_INTRODUCER:
-        *Type = EXTENSION_RECORD_TYPE;
-        break;
-    case TERMINATOR_INTRODUCER:
-        *Type = TERMINATE_RECORD_TYPE;
-        break;
-    default:
-        *Type = UNDEFINED_RECORD_TYPE;
-        GifFile->Error = D_GIF_ERR_WRONG_RECORD;
-        return GIF_ERROR;
-    }
+        // fprintf(stderr, "### DGifGetRecordType: %02x\n", Buf);
+        switch (Buf) {
+        case DESCRIPTOR_INTRODUCER:
+                *Type = IMAGE_DESC_RECORD_TYPE;
+                break;
+        case EXTENSION_INTRODUCER:
+                *Type = EXTENSION_RECORD_TYPE;
+                break;
+        case TERMINATOR_INTRODUCER:
+                *Type = TERMINATE_RECORD_TYPE;
+                break;
+        default:
+                *Type = UNDEFINED_RECORD_TYPE;
+                GifFile->Error = D_GIF_ERR_WRONG_RECORD;
+                return GIF_ERROR;
+        }
 
-    return GIF_OK;
+        return GIF_OK;
 }
 
 int DGifGetImageHeader(GifFileType *GifFile) {
-    unsigned int BitsPerPixel;
-    GifByteType Buf[3];
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        unsigned int BitsPerPixel;
+        GifByteType Buf[3];
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-
-    if (DGifGetWord(GifFile, &GifFile->Image.Left) == GIF_ERROR ||
-        DGifGetWord(GifFile, &GifFile->Image.Top) == GIF_ERROR ||
-        DGifGetWord(GifFile, &GifFile->Image.Width) == GIF_ERROR ||
-        DGifGetWord(GifFile, &GifFile->Image.Height) == GIF_ERROR) {
-        return GIF_ERROR;
-    }
-    if (InternalRead(GifFile, Buf, 1) != 1) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        GifFreeMapObject(GifFile->Image.ColorMap);
-        GifFile->Image.ColorMap = NULL;
-        return GIF_ERROR;
-    }
-    BitsPerPixel = (Buf[0] & 0x07) + 1;
-    GifFile->Image.Interlace = (Buf[0] & 0x40) ? true : false;
-
-    /* Setup the colormap */
-    if (GifFile->Image.ColorMap) {
-        GifFreeMapObject(GifFile->Image.ColorMap);
-        GifFile->Image.ColorMap = NULL;
-    }
-    /* Does this image have local color map? */
-    if (Buf[0] & 0x80) {
-        unsigned int i;
-
-        GifFile->Image.ColorMap =
-            GifMakeMapObject(1 << BitsPerPixel, NULL);
-        if (GifFile->Image.ColorMap == NULL) {
-            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
-            return GIF_ERROR;
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
         }
 
-        /* Get the image local color map: */
-        for (i = 0; i < GifFile->Image.ColorMap->ColorCount; i++) {
-            /* coverity[check_return] */
-            if (InternalRead(GifFile, Buf, 3) != 3) {
-                GifFreeMapObject(GifFile->Image.ColorMap);
+        if (DGifGetWord(GifFile, &GifFile->Image.Left) == GIF_ERROR ||
+            DGifGetWord(GifFile, &GifFile->Image.Top) == GIF_ERROR ||
+            DGifGetWord(GifFile, &GifFile->Image.Width) == GIF_ERROR ||
+            DGifGetWord(GifFile, &GifFile->Image.Height) == GIF_ERROR) {
+                return GIF_ERROR;
+        }
+        if (InternalRead(GifFile, Buf, 1) != 1) {
                 GifFile->Error = D_GIF_ERR_READ_FAILED;
+                GifFreeMapObject(GifFile->Image.ColorMap);
                 GifFile->Image.ColorMap = NULL;
                 return GIF_ERROR;
-            }
-            GifFile->Image.ColorMap->Colors[i].Red = Buf[0];
-            GifFile->Image.ColorMap->Colors[i].Green = Buf[1];
-            GifFile->Image.ColorMap->Colors[i].Blue = Buf[2];
         }
-    }
+        BitsPerPixel = (Buf[0] & 0x07) + 1;
+        GifFile->Image.Interlace = (Buf[0] & 0x40) ? true : false;
 
-    Private->PixelCount =
-        (long)GifFile->Image.Width * (long)GifFile->Image.Height;
+        /* Setup the colormap */
+        if (GifFile->Image.ColorMap) {
+                GifFreeMapObject(GifFile->Image.ColorMap);
+                GifFile->Image.ColorMap = NULL;
+        }
+        /* Does this image have local color map? */
+        if (Buf[0] & 0x80) {
+                unsigned int i;
 
-    /* Reset decompress algorithm parameters. */
-    return DGifSetupDecompress(GifFile);
+                GifFile->Image.ColorMap =
+                    GifMakeMapObject(1 << BitsPerPixel, NULL);
+                if (GifFile->Image.ColorMap == NULL) {
+                        GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                        return GIF_ERROR;
+                }
+
+                /* Get the image local color map: */
+                for (i = 0; i < GifFile->Image.ColorMap->ColorCount; i++) {
+                        /* coverity[check_return] */
+                        if (InternalRead(GifFile, Buf, 3) != 3) {
+                                GifFreeMapObject(GifFile->Image.ColorMap);
+                                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                                GifFile->Image.ColorMap = NULL;
+                                return GIF_ERROR;
+                        }
+                        GifFile->Image.ColorMap->Colors[i].Red = Buf[0];
+                        GifFile->Image.ColorMap->Colors[i].Green = Buf[1];
+                        GifFile->Image.ColorMap->Colors[i].Blue = Buf[2];
+                }
+        }
+
+        Private->PixelCount =
+            (long)GifFile->Image.Width * (long)GifFile->Image.Height;
+
+        /* Reset decompress algorithm parameters. */
+        return DGifSetupDecompress(GifFile);
 }
 
 /******************************************************************************
@@ -451,133 +451,135 @@ int DGifGetImageHeader(GifFileType *GifFile) {
  Note it is assumed the Image desc. header has been read.
 ******************************************************************************/
 int DGifGetImageDesc(GifFileType *GifFile) {
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
-    SavedImage *sp;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        SavedImage *sp;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-
-    if (DGifGetImageHeader(GifFile) == GIF_ERROR) {
-        return GIF_ERROR;
-    }
-
-    if (GifFile->SavedImages) {
-        SavedImage *new_saved_images = (SavedImage *)reallocarray(
-            GifFile->SavedImages, (GifFile->ImageCount + 1),
-            sizeof(SavedImage));
-        if (new_saved_images == NULL) {
-            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
-            return GIF_ERROR;
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
         }
-        GifFile->SavedImages = new_saved_images;
-    } else {
-        if ((GifFile->SavedImages =
-                 (SavedImage *)malloc(sizeof(SavedImage))) == NULL) {
-            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
-            return GIF_ERROR;
+
+        if (DGifGetImageHeader(GifFile) == GIF_ERROR) {
+                return GIF_ERROR;
         }
-    }
 
-    sp = &GifFile->SavedImages[GifFile->ImageCount];
-    memcpy(&sp->ImageDesc, &GifFile->Image, sizeof(GifImageDesc));
-    if (GifFile->Image.ColorMap != NULL) {
-        sp->ImageDesc.ColorMap =
-            GifMakeMapObject(GifFile->Image.ColorMap->ColorCount,
-                             GifFile->Image.ColorMap->Colors);
-        if (sp->ImageDesc.ColorMap == NULL) {
-            GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
-            return GIF_ERROR;
+        if (GifFile->SavedImages) {
+                SavedImage *new_saved_images = (SavedImage *)reallocarray(
+                    GifFile->SavedImages, (GifFile->ImageCount + 1),
+                    sizeof(SavedImage));
+                if (new_saved_images == NULL) {
+                        GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                        return GIF_ERROR;
+                }
+                GifFile->SavedImages = new_saved_images;
+        } else {
+                if ((GifFile->SavedImages =
+                         (SavedImage *)malloc(sizeof(SavedImage))) == NULL) {
+                        GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                        return GIF_ERROR;
+                }
         }
-    }
-    sp->RasterBits = (unsigned char *)NULL;
-    sp->ExtensionBlockCount = 0;
-    sp->ExtensionBlocks = (ExtensionBlock *)NULL;
 
-    GifFile->ImageCount++;
+        sp = &GifFile->SavedImages[GifFile->ImageCount];
+        memcpy(&sp->ImageDesc, &GifFile->Image, sizeof(GifImageDesc));
+        if (GifFile->Image.ColorMap != NULL) {
+                sp->ImageDesc.ColorMap =
+                    GifMakeMapObject(GifFile->Image.ColorMap->ColorCount,
+                                     GifFile->Image.ColorMap->Colors);
+                if (sp->ImageDesc.ColorMap == NULL) {
+                        GifFile->Error = D_GIF_ERR_NOT_ENOUGH_MEM;
+                        return GIF_ERROR;
+                }
+        }
+        sp->RasterBits = (unsigned char *)NULL;
+        sp->ExtensionBlockCount = 0;
+        sp->ExtensionBlocks = (ExtensionBlock *)NULL;
 
-    return GIF_OK;
+        GifFile->ImageCount++;
+
+        return GIF_OK;
 }
 
 /******************************************************************************
  Get one full scanned line (Line) of length LineLen from GIF file.
 ******************************************************************************/
 int DGifGetLine(GifFileType *GifFile, GifPixelType *Line, int LineLen) {
-    GifByteType *Dummy;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType *Dummy;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-
-    if (!LineLen) {
-        LineLen = GifFile->Image.Width;
-    }
-
-    if ((Private->PixelCount -= LineLen) > 0xffff0000UL) {
-        GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
-        return GIF_ERROR;
-    }
-
-    if (DGifDecompressLine(GifFile, Line, LineLen) == GIF_OK) {
-        if (Private->PixelCount == 0) {
-            /* We probably won't be called any more, so let's clean
-             * up everything before we return: need to flush out all
-             * the rest of image until an empty block (size 0)
-             * detected. We use GetCodeNext.
-             */
-            do {
-                if (DGifGetCodeNext(GifFile, &Dummy) ==
-                    GIF_ERROR) {
-                    return GIF_ERROR;
-                }
-            } while (Dummy != NULL);
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
         }
-        return GIF_OK;
-    } else {
-        return GIF_ERROR;
-    }
+
+        if (!LineLen) {
+                LineLen = GifFile->Image.Width;
+        }
+
+        if (LineLen < 0 || Private->PixelCount < (unsigned long)LineLen) {
+                GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
+                return GIF_ERROR;
+        }
+        Private->PixelCount -= LineLen;
+
+        if (DGifDecompressLine(GifFile, Line, LineLen) == GIF_OK) {
+                if (Private->PixelCount == 0) {
+                        /* We probably won't be called any more, so let's clean
+                         * up everything before we return: need to flush out all
+                         * the rest of image until an empty block (size 0)
+                         * detected. We use GetCodeNext.
+                         */
+                        do {
+                                if (DGifGetCodeNext(GifFile, &Dummy) ==
+                                    GIF_ERROR) {
+                                        return GIF_ERROR;
+                                }
+                        } while (Dummy != NULL);
+                }
+                return GIF_OK;
+        } else {
+                return GIF_ERROR;
+        }
 }
 
 /******************************************************************************
  Put one pixel (Pixel) into GIF file.
 ******************************************************************************/
 int DGifGetPixel(GifFileType *GifFile, GifPixelType Pixel) {
-    GifByteType *Dummy;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType *Dummy;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-    if (--Private->PixelCount > 0xffff0000UL) {
-        GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
-        return GIF_ERROR;
-    }
-
-    if (DGifDecompressLine(GifFile, &Pixel, 1) == GIF_OK) {
-        if (Private->PixelCount == 0) {
-            /* We probably won't be called any more, so let's clean
-             * up everything before we return: need to flush out all
-             * the rest of image until an empty block (size 0)
-             * detected. We use GetCodeNext.
-             */
-            do {
-                if (DGifGetCodeNext(GifFile, &Dummy) ==
-                    GIF_ERROR) {
-                    return GIF_ERROR;
-                }
-            } while (Dummy != NULL);
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
         }
-        return GIF_OK;
-    } else {
-        return GIF_ERROR;
-    }
+        if (Private->PixelCount == 0) {
+                GifFile->Error = D_GIF_ERR_DATA_TOO_BIG;
+                return GIF_ERROR;
+        }
+        Private->PixelCount --;
+
+        if (DGifDecompressLine(GifFile, &Pixel, 1) == GIF_OK) {
+                if (Private->PixelCount == 0) {
+                        /* We probably won't be called any more, so let's clean
+                         * up everything before we return: need to flush out all
+                         * the rest of image until an empty block (size 0)
+                         * detected. We use GetCodeNext.
+                         */
+                        do {
+                                if (DGifGetCodeNext(GifFile, &Dummy) ==
+                                    GIF_ERROR) {
+                                        return GIF_ERROR;
+                                }
+                        } while (Dummy != NULL);
+                }
+                return GIF_OK;
+        } else {
+                return GIF_ERROR;
+        }
 }
 
 /******************************************************************************
@@ -589,26 +591,26 @@ int DGifGetPixel(GifFileType *GifFile, GifPixelType Pixel) {
 ******************************************************************************/
 int DGifGetExtension(GifFileType *GifFile, int *ExtCode,
                      GifByteType **Extension) {
-    GifByteType Buf;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType Buf;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    // fprintf(stderr, "### -> DGifGetExtension:\n");
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
+        // fprintf(stderr, "### -> DGifGetExtension:\n");
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
+        }
 
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, &Buf, 1) != 1) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR;
-    }
-    *ExtCode = Buf;
-    // fprintf(stderr, "### <- DGifGetExtension: %02x, about to call
-    // next\n", Buf);
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, &Buf, 1) != 1) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
+        }
+        *ExtCode = Buf;
+        // fprintf(stderr, "### <- DGifGetExtension: %02x, about to call
+        // next\n", Buf);
 
-    return DGifGetExtensionNext(GifFile, Extension);
+        return DGifGetExtensionNext(GifFile, Extension);
 }
 
 /******************************************************************************
@@ -617,31 +619,31 @@ int DGifGetExtension(GifFileType *GifFile, int *ExtCode,
  The Extension should NOT be freed by the user (not dynamically allocated).
 ******************************************************************************/
 int DGifGetExtensionNext(GifFileType *GifFile, GifByteType **Extension) {
-    GifByteType Buf;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType Buf;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    // fprintf(stderr, "### -> DGifGetExtensionNext\n");
-    if (InternalRead(GifFile, &Buf, 1) != 1) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR;
-    }
-    // fprintf(stderr, "### DGifGetExtensionNext sees %d\n", Buf);
-
-    if (Buf > 0) {
-        *Extension = Private->Buf; /* Use private unused buffer. */
-        (*Extension)[0] =
-            Buf; /* Pascal strings notation (pos. 0 is len.). */
-                 /* coverity[tainted_data,check_return] */
-        if (InternalRead(GifFile, &((*Extension)[1]), Buf) != Buf) {
-            GifFile->Error = D_GIF_ERR_READ_FAILED;
-            return GIF_ERROR;
+        // fprintf(stderr, "### -> DGifGetExtensionNext\n");
+        if (InternalRead(GifFile, &Buf, 1) != 1) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
         }
-    } else {
-        *Extension = NULL;
-    }
-    // fprintf(stderr, "### <- DGifGetExtensionNext: %p\n", Extension);
+        // fprintf(stderr, "### DGifGetExtensionNext sees %d\n", Buf);
 
-    return GIF_OK;
+        if (Buf > 0) {
+                *Extension = Private->Buf; /* Use private unused buffer. */
+                (*Extension)[0] =
+                    Buf; /* Pascal strings notation (pos. 0 is len.). */
+                         /* coverity[tainted_data,check_return] */
+                if (InternalRead(GifFile, &((*Extension)[1]), Buf) != Buf) {
+                        GifFile->Error = D_GIF_ERR_READ_FAILED;
+                        return GIF_ERROR;
+                }
+        } else {
+                *Extension = NULL;
+        }
+        // fprintf(stderr, "### <- DGifGetExtensionNext: %p\n", Extension);
+
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -651,21 +653,21 @@ int DGifGetExtensionNext(GifFileType *GifFile, GifByteType **Extension) {
 int DGifExtensionToGCB(const size_t GifExtensionLength,
                        const GifByteType *GifExtension,
                        GraphicsControlBlock *GCB) {
-    if (GifExtensionLength != 4) {
-        return GIF_ERROR;
-    }
+        if (GifExtensionLength != 4) {
+                return GIF_ERROR;
+        }
 
-    GCB->DisposalMode = (GifExtension[0] >> 2) & 0x07;
-    GCB->UserInputFlag = (GifExtension[0] & 0x02) != 0;
-    GCB->DelayTime =
-        UNSIGNED_LITTLE_ENDIAN(GifExtension[1], GifExtension[2]);
-    if (GifExtension[0] & 0x01) {
-        GCB->TransparentColor = (int)GifExtension[3];
-    } else {
-        GCB->TransparentColor = NO_TRANSPARENT_COLOR;
-    }
+        GCB->DisposalMode = (GifExtension[0] >> 2) & 0x07;
+        GCB->UserInputFlag = (GifExtension[0] & 0x02) != 0;
+        GCB->DelayTime =
+            UNSIGNED_LITTLE_ENDIAN(GifExtension[1], GifExtension[2]);
+        if (GifExtension[0] & 0x01) {
+                GCB->TransparentColor = (int)GifExtension[3];
+        } else {
+                GCB->TransparentColor = NO_TRANSPARENT_COLOR;
+        }
 
-    return GIF_OK;
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -674,101 +676,101 @@ int DGifExtensionToGCB(const size_t GifExtensionLength,
 
 int DGifSavedExtensionToGCB(GifFileType *GifFile, int ImageIndex,
                             GraphicsControlBlock *GCB) {
-    int i;
+        int i;
 
-    if (ImageIndex < 0 || ImageIndex > GifFile->ImageCount - 1) {
-        return GIF_ERROR;
-    }
-
-    GCB->DisposalMode = DISPOSAL_UNSPECIFIED;
-    GCB->UserInputFlag = false;
-    GCB->DelayTime = 0;
-    GCB->TransparentColor = NO_TRANSPARENT_COLOR;
-
-    for (i = 0; i < GifFile->SavedImages[ImageIndex].ExtensionBlockCount;
-         i++) {
-        ExtensionBlock *ep =
-            &GifFile->SavedImages[ImageIndex].ExtensionBlocks[i];
-        if (ep->Function == GRAPHICS_EXT_FUNC_CODE) {
-            return DGifExtensionToGCB(ep->ByteCount, ep->Bytes,
-                                      GCB);
+        if (ImageIndex < 0 || ImageIndex > GifFile->ImageCount - 1) {
+                return GIF_ERROR;
         }
-    }
 
-    return GIF_ERROR;
+        GCB->DisposalMode = DISPOSAL_UNSPECIFIED;
+        GCB->UserInputFlag = false;
+        GCB->DelayTime = 0;
+        GCB->TransparentColor = NO_TRANSPARENT_COLOR;
+
+        for (i = 0; i < GifFile->SavedImages[ImageIndex].ExtensionBlockCount;
+             i++) {
+                ExtensionBlock *ep =
+                    &GifFile->SavedImages[ImageIndex].ExtensionBlocks[i];
+                if (ep->Function == GRAPHICS_EXT_FUNC_CODE) {
+                        return DGifExtensionToGCB(ep->ByteCount, ep->Bytes,
+                                                  GCB);
+                }
+        }
+
+        return GIF_ERROR;
 }
 
 /******************************************************************************
  This routine should be called last, to close the GIF file.
 ******************************************************************************/
 int DGifCloseFile(GifFileType *GifFile, int *ErrorCode) {
-    GifFilePrivateType *Private;
+        GifFilePrivateType *Private;
 
-    if (GifFile == NULL || GifFile->Private == NULL) {
-        return GIF_ERROR;
-    }
-
-    if (GifFile->Image.ColorMap) {
-        GifFreeMapObject(GifFile->Image.ColorMap);
-        GifFile->Image.ColorMap = NULL;
-    }
-
-    if (GifFile->SColorMap) {
-        GifFreeMapObject(GifFile->SColorMap);
-        GifFile->SColorMap = NULL;
-    }
-
-    if (GifFile->SavedImages) {
-        GifFreeSavedImages(GifFile);
-        GifFile->SavedImages = NULL;
-    }
-
-    GifFreeExtensions(&GifFile->ExtensionBlockCount,
-                      &GifFile->ExtensionBlocks);
-
-    Private = (GifFilePrivateType *)GifFile->Private;
-
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        if (ErrorCode != NULL) {
-            *ErrorCode = D_GIF_ERR_NOT_READABLE;
+        if (GifFile == NULL || GifFile->Private == NULL) {
+                return GIF_ERROR;
         }
+
+        if (GifFile->Image.ColorMap) {
+                GifFreeMapObject(GifFile->Image.ColorMap);
+                GifFile->Image.ColorMap = NULL;
+        }
+
+        if (GifFile->SColorMap) {
+                GifFreeMapObject(GifFile->SColorMap);
+                GifFile->SColorMap = NULL;
+        }
+
+        if (GifFile->SavedImages) {
+                GifFreeSavedImages(GifFile);
+                GifFile->SavedImages = NULL;
+        }
+
+        GifFreeExtensions(&GifFile->ExtensionBlockCount,
+                          &GifFile->ExtensionBlocks);
+
+        Private = (GifFilePrivateType *)GifFile->Private;
+
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                if (ErrorCode != NULL) {
+                        *ErrorCode = D_GIF_ERR_NOT_READABLE;
+                }
+                free((char *)GifFile->Private);
+                free(GifFile);
+                return GIF_ERROR;
+        }
+
+        if (Private->File && (fclose(Private->File) != 0)) {
+                if (ErrorCode != NULL) {
+                        *ErrorCode = D_GIF_ERR_CLOSE_FAILED;
+                }
+                free((char *)GifFile->Private);
+                free(GifFile);
+                return GIF_ERROR;
+        }
+
         free((char *)GifFile->Private);
         free(GifFile);
-        return GIF_ERROR;
-    }
-
-    if (Private->File && (fclose(Private->File) != 0)) {
         if (ErrorCode != NULL) {
-            *ErrorCode = D_GIF_ERR_CLOSE_FAILED;
+                *ErrorCode = D_GIF_SUCCEEDED;
         }
-        free((char *)GifFile->Private);
-        free(GifFile);
-        return GIF_ERROR;
-    }
-
-    free((char *)GifFile->Private);
-    free(GifFile);
-    if (ErrorCode != NULL) {
-        *ErrorCode = D_GIF_SUCCEEDED;
-    }
-    return GIF_OK;
+        return GIF_OK;
 }
 
 /******************************************************************************
  Get 2 bytes (word) from the given file:
 ******************************************************************************/
 static int DGifGetWord(GifFileType *GifFile, GifWord *Word) {
-    unsigned char c[2];
+        unsigned char c[2];
 
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, c, 2) != 2) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR;
-    }
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, c, 2) != 2) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
+        }
 
-    *Word = (GifWord)UNSIGNED_LITTLE_ENDIAN(c[0], c[1]);
-    return GIF_OK;
+        *Word = (GifWord)UNSIGNED_LITTLE_ENDIAN(c[0], c[1]);
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -779,17 +781,17 @@ static int DGifGetWord(GifFileType *GifFile, GifWord *Word) {
  The block should NOT be freed by the user (not dynamically allocated).
 ******************************************************************************/
 int DGifGetCode(GifFileType *GifFile, int *CodeSize, GifByteType **CodeBlock) {
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
+                return GIF_ERROR;
+        }
 
-    *CodeSize = Private->BitsPerPixel;
+        *CodeSize = Private->BitsPerPixel;
 
-    return DGifGetCodeNext(GifFile, CodeBlock);
+        return DGifGetCodeNext(GifFile, CodeBlock);
 }
 
 /******************************************************************************
@@ -798,78 +800,78 @@ int DGifGetCode(GifFileType *GifFile, int *CodeSize, GifByteType **CodeBlock) {
  The block should NOT be freed by the user (not dynamically allocated).
 ******************************************************************************/
 int DGifGetCodeNext(GifFileType *GifFile, GifByteType **CodeBlock) {
-    GifByteType Buf;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType Buf;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    /* coverity[tainted_data_argument] */
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, &Buf, 1) != 1) {
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR;
-    }
-
-    /* coverity[lower_bounds] */
-    if (Buf > 0) {
-        *CodeBlock = Private->Buf; /* Use private unused buffer. */
-        (*CodeBlock)[0] =
-            Buf; /* Pascal strings notation (pos. 0 is len.). */
-                 /* coverity[tainted_data] */
-        if (InternalRead(GifFile, &((*CodeBlock)[1]), Buf) != Buf) {
-            GifFile->Error = D_GIF_ERR_READ_FAILED;
-            return GIF_ERROR;
+        /* coverity[tainted_data_argument] */
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, &Buf, 1) != 1) {
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR;
         }
-    } else {
-        *CodeBlock = NULL;
-        Private->Buf[0] = 0; /* Make sure the buffer is empty! */
-        Private->PixelCount =
-            0; /* And local info. indicate image read. */
-    }
 
-    return GIF_OK;
+        /* coverity[lower_bounds] */
+        if (Buf > 0) {
+                *CodeBlock = Private->Buf; /* Use private unused buffer. */
+                (*CodeBlock)[0] =
+                    Buf; /* Pascal strings notation (pos. 0 is len.). */
+                         /* coverity[tainted_data] */
+                if (InternalRead(GifFile, &((*CodeBlock)[1]), Buf) != Buf) {
+                        GifFile->Error = D_GIF_ERR_READ_FAILED;
+                        return GIF_ERROR;
+                }
+        } else {
+                *CodeBlock = NULL;
+                Private->Buf[0] = 0; /* Make sure the buffer is empty! */
+                Private->PixelCount =
+                    0; /* And local info. indicate image read. */
+        }
+
+        return GIF_OK;
 }
 
 /******************************************************************************
  Setup the LZ decompression for this image:
 ******************************************************************************/
 static int DGifSetupDecompress(GifFileType *GifFile) {
-    int i, BitsPerPixel;
-    GifByteType CodeSize;
-    GifPrefixType *Prefix;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        int i, BitsPerPixel;
+        GifByteType CodeSize;
+        GifPrefixType *Prefix;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    /* coverity[check_return] */
-    if (InternalRead(GifFile, &CodeSize, 1) <
-        1) { /* Read Code size from file. */
-        GifFile->Error = D_GIF_ERR_READ_FAILED;
-        return GIF_ERROR; /* Failed to read Code size. */
-    }
-    BitsPerPixel = CodeSize;
+        /* coverity[check_return] */
+        if (InternalRead(GifFile, &CodeSize, 1) <
+            1) { /* Read Code size from file. */
+                GifFile->Error = D_GIF_ERR_READ_FAILED;
+                return GIF_ERROR; /* Failed to read Code size. */
+        }
+        BitsPerPixel = CodeSize;
 
-    /* this can only happen on a severely malformed GIF */
-    if (BitsPerPixel > 8) {
-        GifFile->Error =
-            D_GIF_ERR_READ_FAILED; /* somewhat bogus error code */
-        return GIF_ERROR;          /* Failed to read Code size. */
-    }
+        /* this can only happen on a severely malformed GIF */
+        if (BitsPerPixel > 8) {
+                GifFile->Error =
+                    D_GIF_ERR_READ_FAILED; /* somewhat bogus error code */
+                return GIF_ERROR;          /* Failed to read Code size. */
+        }
 
-    Private->Buf[0] = 0; /* Input Buffer empty. */
-    Private->BitsPerPixel = BitsPerPixel;
-    Private->ClearCode = (1 << BitsPerPixel);
-    Private->EOFCode = Private->ClearCode + 1;
-    Private->RunningCode = Private->EOFCode + 1;
-    Private->RunningBits = BitsPerPixel + 1; /* Number of bits per code. */
-    Private->MaxCode1 = 1 << Private->RunningBits; /* Max. code + 1. */
-    Private->StackPtr = 0; /* No pixels on the pixel stack. */
-    Private->LastCode = NO_SUCH_CODE;
-    Private->CrntShiftState = 0; /* No information in CrntShiftDWord. */
-    Private->CrntShiftDWord = 0;
+        Private->Buf[0] = 0; /* Input Buffer empty. */
+        Private->BitsPerPixel = BitsPerPixel;
+        Private->ClearCode = (1 << BitsPerPixel);
+        Private->EOFCode = Private->ClearCode + 1;
+        Private->RunningCode = Private->EOFCode + 1;
+        Private->RunningBits = BitsPerPixel + 1; /* Number of bits per code. */
+        Private->MaxCode1 = 1 << Private->RunningBits; /* Max. code + 1. */
+        Private->StackPtr = 0; /* No pixels on the pixel stack. */
+        Private->LastCode = NO_SUCH_CODE;
+        Private->CrntShiftState = 0; /* No information in CrntShiftDWord. */
+        Private->CrntShiftDWord = 0;
 
-    Prefix = Private->Prefix;
-    for (i = 0; i <= LZ_MAX_CODE; i++) {
-        Prefix[i] = NO_SUCH_CODE;
-    }
+        Prefix = Private->Prefix;
+        for (i = 0; i <= LZ_MAX_CODE; i++) {
+                Prefix[i] = NO_SUCH_CODE;
+        }
 
-    return GIF_OK;
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -880,147 +882,147 @@ static int DGifSetupDecompress(GifFileType *GifFile) {
 ******************************************************************************/
 static int DGifDecompressLine(GifFileType *GifFile, GifPixelType *Line,
                               int LineLen) {
-    int i = 0;
-    int j, CrntCode, EOFCode, ClearCode, CrntPrefix, LastCode, StackPtr;
-    GifByteType *Stack, *Suffix;
-    GifPrefixType *Prefix;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        int i = 0;
+        int j, CrntCode, EOFCode, ClearCode, CrntPrefix, LastCode, StackPtr;
+        GifByteType *Stack, *Suffix;
+        GifPrefixType *Prefix;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    StackPtr = Private->StackPtr;
-    Prefix = Private->Prefix;
-    Suffix = Private->Suffix;
-    Stack = Private->Stack;
-    EOFCode = Private->EOFCode;
-    ClearCode = Private->ClearCode;
-    LastCode = Private->LastCode;
+        StackPtr = Private->StackPtr;
+        Prefix = Private->Prefix;
+        Suffix = Private->Suffix;
+        Stack = Private->Stack;
+        EOFCode = Private->EOFCode;
+        ClearCode = Private->ClearCode;
+        LastCode = Private->LastCode;
 
-    if (StackPtr > LZ_MAX_CODE) {
-        return GIF_ERROR;
-    }
-
-    if (StackPtr != 0) {
-        /* Let pop the stack off before continueing to read the GIF
-         * file: */
-        while (StackPtr != 0 && i < LineLen) {
-            Line[i++] = Stack[--StackPtr];
-        }
-    }
-
-    while (i < LineLen) { /* Decode LineLen items. */
-        if (DGifDecompressInput(GifFile, &CrntCode) == GIF_ERROR) {
-            return GIF_ERROR;
+        if (StackPtr > LZ_MAX_CODE) {
+                return GIF_ERROR;
         }
 
-        if (CrntCode == EOFCode) {
-            /* Note however that usually we will not be here as we
-             * will stop decoding as soon as we got all the pixel,
-             * or EOF code will not be read at all, and
-             * DGifGetLine/Pixel clean everything.  */
-            GifFile->Error = D_GIF_ERR_EOF_TOO_SOON;
-            return GIF_ERROR;
-        } else if (CrntCode == ClearCode) {
-            /* We need to start over again: */
-            for (j = 0; j <= LZ_MAX_CODE; j++) {
-                Prefix[j] = NO_SUCH_CODE;
-            }
-            Private->RunningCode = Private->EOFCode + 1;
-            Private->RunningBits = Private->BitsPerPixel + 1;
-            Private->MaxCode1 = 1 << Private->RunningBits;
-            LastCode = Private->LastCode = NO_SUCH_CODE;
-        } else {
-            /* Its regular code - if in pixel range simply add it to
-             * output stream, otherwise trace to codes linked list
-             * until the prefix is in pixel range: */
-            if (CrntCode < ClearCode) {
-                /* This is simple - its pixel scalar, so add it
-                 * to output: */
-                Line[i++] = CrntCode;
-            } else {
-                /* Its a code to needed to be traced: trace the
-                 * linked list until the prefix is a pixel,
-                 * while pushing the suffix pixels on our stack.
-                 * If we done, pop the stack in reverse (thats
-                 * what stack is good for!) order to output.  */
-                if (Prefix[CrntCode] == NO_SUCH_CODE) {
-                    CrntPrefix = LastCode;
-
-                    /* Only allowed if CrntCode is exactly
-                     * the running code: In that case
-                     * CrntCode = XXXCode, CrntCode or the
-                     * prefix code is last code and the
-                     * suffix char is exactly the prefix of
-                     * last code! */
-                    if (CrntCode ==
-                        Private->RunningCode - 2) {
-                        Suffix[Private->RunningCode -
-                               2] = Stack[StackPtr++] =
-                            DGifGetPrefixChar(
-                                Prefix, LastCode,
-                                ClearCode);
-                    } else {
-                        Suffix[Private->RunningCode -
-                               2] = Stack[StackPtr++] =
-                            DGifGetPrefixChar(
-                                Prefix, CrntCode,
-                                ClearCode);
-                    }
-                } else {
-                    CrntPrefix = CrntCode;
-                }
-
-                /* Now (if image is O.K.) we should not get a
-                 * NO_SUCH_CODE during the trace. As we might
-                 * loop forever, in case of defective image, we
-                 * use StackPtr as loop counter and stop before
-                 * overflowing Stack[]. */
-                while (StackPtr < LZ_MAX_CODE &&
-                       CrntPrefix > ClearCode &&
-                       CrntPrefix <= LZ_MAX_CODE) {
-                    Stack[StackPtr++] = Suffix[CrntPrefix];
-                    CrntPrefix = Prefix[CrntPrefix];
-                }
-                if (StackPtr >= LZ_MAX_CODE ||
-                    CrntPrefix > LZ_MAX_CODE) {
-                    GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
-                    return GIF_ERROR;
-                }
-                /* Push the last character on stack: */
-                Stack[StackPtr++] = CrntPrefix;
-
-                /* Now lets pop all the stack into output: */
+        if (StackPtr != 0) {
+                /* Let pop the stack off before continueing to read the GIF
+                 * file: */
                 while (StackPtr != 0 && i < LineLen) {
-                    Line[i++] = Stack[--StackPtr];
+                        Line[i++] = Stack[--StackPtr];
                 }
-            }
-            if (LastCode != NO_SUCH_CODE &&
-                Private->RunningCode - 2 < (LZ_MAX_CODE + 1) &&
-                Prefix[Private->RunningCode - 2] == NO_SUCH_CODE) {
-                Prefix[Private->RunningCode - 2] = LastCode;
-
-                if (CrntCode == Private->RunningCode - 2) {
-                    /* Only allowed if CrntCode is exactly
-                     * the running code: In that case
-                     * CrntCode = XXXCode, CrntCode or the
-                     * prefix code is last code and the
-                     * suffix char is exactly the prefix of
-                     * last code! */
-                    Suffix[Private->RunningCode - 2] =
-                        DGifGetPrefixChar(Prefix, LastCode,
-                                          ClearCode);
-                } else {
-                    Suffix[Private->RunningCode - 2] =
-                        DGifGetPrefixChar(Prefix, CrntCode,
-                                          ClearCode);
-                }
-            }
-            LastCode = CrntCode;
         }
-    }
 
-    Private->LastCode = LastCode;
-    Private->StackPtr = StackPtr;
+        while (i < LineLen) { /* Decode LineLen items. */
+                if (DGifDecompressInput(GifFile, &CrntCode) == GIF_ERROR) {
+                        return GIF_ERROR;
+                }
 
-    return GIF_OK;
+                if (CrntCode == EOFCode) {
+                        /* Note however that usually we will not be here as we
+                         * will stop decoding as soon as we got all the pixel,
+                         * or EOF code will not be read at all, and
+                         * DGifGetLine/Pixel clean everything.  */
+                        GifFile->Error = D_GIF_ERR_EOF_TOO_SOON;
+                        return GIF_ERROR;
+                } else if (CrntCode == ClearCode) {
+                        /* We need to start over again: */
+                        for (j = 0; j <= LZ_MAX_CODE; j++) {
+                                Prefix[j] = NO_SUCH_CODE;
+                        }
+                        Private->RunningCode = Private->EOFCode + 1;
+                        Private->RunningBits = Private->BitsPerPixel + 1;
+                        Private->MaxCode1 = 1 << Private->RunningBits;
+                        LastCode = Private->LastCode = NO_SUCH_CODE;
+                } else {
+                        /* Its regular code - if in pixel range simply add it to
+                         * output stream, otherwise trace to codes linked list
+                         * until the prefix is in pixel range: */
+                        if (CrntCode < ClearCode) {
+                                /* This is simple - its pixel scalar, so add it
+                                 * to output: */
+                                Line[i++] = CrntCode;
+                        } else {
+                                /* Its a code to needed to be traced: trace the
+                                 * linked list until the prefix is a pixel,
+                                 * while pushing the suffix pixels on our stack.
+                                 * If we done, pop the stack in reverse (thats
+                                 * what stack is good for!) order to output.  */
+                                if (Prefix[CrntCode] == NO_SUCH_CODE) {
+                                        CrntPrefix = LastCode;
+
+                                        /* Only allowed if CrntCode is exactly
+                                         * the running code: In that case
+                                         * CrntCode = XXXCode, CrntCode or the
+                                         * prefix code is last code and the
+                                         * suffix char is exactly the prefix of
+                                         * last code! */
+                                        if (CrntCode ==
+                                            Private->RunningCode - 2) {
+                                                Suffix[Private->RunningCode -
+                                                       2] = Stack[StackPtr++] =
+                                                    DGifGetPrefixChar(
+                                                        Prefix, LastCode,
+                                                        ClearCode);
+                                        } else {
+                                                Suffix[Private->RunningCode -
+                                                       2] = Stack[StackPtr++] =
+                                                    DGifGetPrefixChar(
+                                                        Prefix, CrntCode,
+                                                        ClearCode);
+                                        }
+                                } else {
+                                        CrntPrefix = CrntCode;
+                                }
+
+                                /* Now (if image is O.K.) we should not get a
+                                 * NO_SUCH_CODE during the trace. As we might
+                                 * loop forever, in case of defective image, we
+                                 * use StackPtr as loop counter and stop before
+                                 * overflowing Stack[]. */
+                                while (StackPtr < LZ_MAX_CODE &&
+                                       CrntPrefix > ClearCode &&
+                                       CrntPrefix <= LZ_MAX_CODE) {
+                                        Stack[StackPtr++] = Suffix[CrntPrefix];
+                                        CrntPrefix = Prefix[CrntPrefix];
+                                }
+                                if (StackPtr >= LZ_MAX_CODE ||
+                                    CrntPrefix > LZ_MAX_CODE) {
+                                        GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+                                        return GIF_ERROR;
+                                }
+                                /* Push the last character on stack: */
+                                Stack[StackPtr++] = CrntPrefix;
+
+                                /* Now lets pop all the stack into output: */
+                                while (StackPtr != 0 && i < LineLen) {
+                                        Line[i++] = Stack[--StackPtr];
+                                }
+                        }
+                        if (LastCode != NO_SUCH_CODE &&
+                            Private->RunningCode - 2 < (LZ_MAX_CODE + 1) &&
+                            Prefix[Private->RunningCode - 2] == NO_SUCH_CODE) {
+                                Prefix[Private->RunningCode - 2] = LastCode;
+
+                                if (CrntCode == Private->RunningCode - 2) {
+                                        /* Only allowed if CrntCode is exactly
+                                         * the running code: In that case
+                                         * CrntCode = XXXCode, CrntCode or the
+                                         * prefix code is last code and the
+                                         * suffix char is exactly the prefix of
+                                         * last code! */
+                                        Suffix[Private->RunningCode - 2] =
+                                            DGifGetPrefixChar(Prefix, LastCode,
+                                                              ClearCode);
+                                } else {
+                                        Suffix[Private->RunningCode - 2] =
+                                            DGifGetPrefixChar(Prefix, CrntCode,
+                                                              ClearCode);
+                                }
+                        }
+                        LastCode = CrntCode;
+                }
+        }
+
+        Private->LastCode = LastCode;
+        Private->StackPtr = StackPtr;
+
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -1031,15 +1033,15 @@ static int DGifDecompressLine(GifFileType *GifFile, GifPixelType *Line,
 ******************************************************************************/
 static int DGifGetPrefixChar(const GifPrefixType *Prefix, int Code,
                              int ClearCode) {
-    int i = 0;
+        int i = 0;
 
-    while (Code > ClearCode && i++ <= LZ_MAX_CODE) {
-        if (Code > LZ_MAX_CODE) {
-            return NO_SUCH_CODE;
+        while (Code > ClearCode && i++ <= LZ_MAX_CODE) {
+                if (Code > LZ_MAX_CODE) {
+                        return NO_SUCH_CODE;
+                }
+                Code = Prefix[Code];
         }
-        Code = Prefix[Code];
-    }
-    return Code;
+        return Code;
 }
 
 /******************************************************************************
@@ -1047,37 +1049,37 @@ static int DGifGetPrefixChar(const GifPrefixType *Prefix, int Code,
  (12bits), or to -1 if EOF code is returned.
 ******************************************************************************/
 int DGifGetLZCodes(GifFileType *GifFile, int *Code) {
-    GifByteType *CodeBlock;
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifByteType *CodeBlock;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    if (!IS_READABLE(Private)) {
-        /* This file was NOT open for reading: */
-        GifFile->Error = D_GIF_ERR_NOT_READABLE;
-        return GIF_ERROR;
-    }
-
-    if (DGifDecompressInput(GifFile, Code) == GIF_ERROR) {
-        return GIF_ERROR;
-    }
-
-    if (*Code == Private->EOFCode) {
-        /* Skip rest of codes (hopefully only NULL terminating block):
-         */
-        do {
-            if (DGifGetCodeNext(GifFile, &CodeBlock) == GIF_ERROR) {
+        if (!IS_READABLE(Private)) {
+                /* This file was NOT open for reading: */
+                GifFile->Error = D_GIF_ERR_NOT_READABLE;
                 return GIF_ERROR;
-            }
-        } while (CodeBlock != NULL);
+        }
 
-        *Code = -1;
-    } else if (*Code == Private->ClearCode) {
-        /* We need to start over again: */
-        Private->RunningCode = Private->EOFCode + 1;
-        Private->RunningBits = Private->BitsPerPixel + 1;
-        Private->MaxCode1 = 1 << Private->RunningBits;
-    }
+        if (DGifDecompressInput(GifFile, Code) == GIF_ERROR) {
+                return GIF_ERROR;
+        }
 
-    return GIF_OK;
+        if (*Code == Private->EOFCode) {
+                /* Skip rest of codes (hopefully only NULL terminating block):
+                 */
+                do {
+                        if (DGifGetCodeNext(GifFile, &CodeBlock) == GIF_ERROR) {
+                                return GIF_ERROR;
+                        }
+                } while (CodeBlock != NULL);
+
+                *Code = -1;
+        } else if (*Code == Private->ClearCode) {
+                /* We need to start over again: */
+                Private->RunningCode = Private->EOFCode + 1;
+                Private->RunningBits = Private->BitsPerPixel + 1;
+                Private->MaxCode1 = 1 << Private->RunningBits;
+        }
+
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -1087,47 +1089,47 @@ int DGifGetLZCodes(GifFileType *GifFile, int *Code) {
  Returns GIF_OK if read successfully.
 ******************************************************************************/
 static int DGifDecompressInput(GifFileType *GifFile, int *Code) {
-    static const unsigned short CodeMasks[] = {
-        0x0000, 0x0001, 0x0003, 0x0007, 0x000f, 0x001f, 0x003f,
-        0x007f, 0x00ff, 0x01ff, 0x03ff, 0x07ff, 0x0fff};
+        static const unsigned short CodeMasks[] = {
+            0x0000, 0x0001, 0x0003, 0x0007, 0x000f, 0x001f, 0x003f,
+            0x007f, 0x00ff, 0x01ff, 0x03ff, 0x07ff, 0x0fff};
 
-    GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
+        GifFilePrivateType *Private = (GifFilePrivateType *)GifFile->Private;
 
-    GifByteType NextByte;
+        GifByteType NextByte;
 
-    /* The image can't contain more than LZ_BITS per code. */
-    if (Private->RunningBits > LZ_BITS) {
-        GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
-        return GIF_ERROR;
-    }
-
-    while (Private->CrntShiftState < Private->RunningBits) {
-        /* Needs to get more bytes from input stream for next code: */
-        if (DGifBufferedInput(GifFile, Private->Buf, &NextByte) ==
-            GIF_ERROR) {
-            return GIF_ERROR;
+        /* The image can't contain more than LZ_BITS per code. */
+        if (Private->RunningBits > LZ_BITS) {
+                GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+                return GIF_ERROR;
         }
-        Private->CrntShiftDWord |= ((unsigned long)NextByte)
-                                   << Private->CrntShiftState;
-        Private->CrntShiftState += 8;
-    }
-    *Code = Private->CrntShiftDWord & CodeMasks[Private->RunningBits];
 
-    Private->CrntShiftDWord >>= Private->RunningBits;
-    Private->CrntShiftState -= Private->RunningBits;
+        while (Private->CrntShiftState < Private->RunningBits) {
+                /* Needs to get more bytes from input stream for next code: */
+                if (DGifBufferedInput(GifFile, Private->Buf, &NextByte) ==
+                    GIF_ERROR) {
+                        return GIF_ERROR;
+                }
+                Private->CrntShiftDWord |= ((unsigned long)NextByte)
+                                           << Private->CrntShiftState;
+                Private->CrntShiftState += 8;
+        }
+        *Code = Private->CrntShiftDWord & CodeMasks[Private->RunningBits];
 
-    /* If code cannot fit into RunningBits bits, must raise its size. Note
-     * however that codes above 4095 are used for special signaling.
-     * If we're using LZ_BITS bits already and we're at the max code, just
-     * keep using the table as it is, don't increment Private->RunningCode.
-     */
-    if (Private->RunningCode < LZ_MAX_CODE + 2 &&
-        ++Private->RunningCode > Private->MaxCode1 &&
-        Private->RunningBits < LZ_BITS) {
-        Private->MaxCode1 <<= 1;
-        Private->RunningBits++;
-    }
-    return GIF_OK;
+        Private->CrntShiftDWord >>= Private->RunningBits;
+        Private->CrntShiftState -= Private->RunningBits;
+
+        /* If code cannot fit into RunningBits bits, must raise its size. Note
+         * however that codes above 4095 are used for special signaling.
+         * If we're using LZ_BITS bits already and we're at the max code, just
+         * keep using the table as it is, don't increment Private->RunningCode.
+         */
+        if (Private->RunningCode < LZ_MAX_CODE + 2 &&
+            ++Private->RunningCode > Private->MaxCode1 &&
+            Private->RunningBits < LZ_BITS) {
+                Private->MaxCode1 <<= 1;
+                Private->RunningBits++;
+        }
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -1138,34 +1140,34 @@ static int DGifDecompressInput(GifFileType *GifFile, int *Code) {
 ******************************************************************************/
 static int DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf,
                              GifByteType *NextByte) {
-    if (Buf[0] == 0) {
-        /* Needs to read the next buffer - this one is empty: */
-        /* coverity[check_return] */
-        if (InternalRead(GifFile, Buf, 1) != 1) {
-            GifFile->Error = D_GIF_ERR_READ_FAILED;
-            return GIF_ERROR;
-        }
-        /* There shouldn't be any empty data blocks here as the LZW spec
-         * says the LZW termination code should come first.  Therefore
-         * we shouldn't be inside this routine at that point.
-         */
         if (Buf[0] == 0) {
-            GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
-            return GIF_ERROR;
+                /* Needs to read the next buffer - this one is empty: */
+                /* coverity[check_return] */
+                if (InternalRead(GifFile, Buf, 1) != 1) {
+                        GifFile->Error = D_GIF_ERR_READ_FAILED;
+                        return GIF_ERROR;
+                }
+                /* There shouldn't be any empty data blocks here as the LZW spec
+                 * says the LZW termination code should come first.  Therefore
+                 * we shouldn't be inside this routine at that point.
+                 */
+                if (Buf[0] == 0) {
+                        GifFile->Error = D_GIF_ERR_IMAGE_DEFECT;
+                        return GIF_ERROR;
+                }
+                if (InternalRead(GifFile, &Buf[1], Buf[0]) != Buf[0]) {
+                        GifFile->Error = D_GIF_ERR_READ_FAILED;
+                        return GIF_ERROR;
+                }
+                *NextByte = Buf[1];
+                Buf[1] = 2; /* We use now the second place as last char read! */
+                Buf[0]--;
+        } else {
+                *NextByte = Buf[Buf[1]++];
+                Buf[0]--;
         }
-        if (InternalRead(GifFile, &Buf[1], Buf[0]) != Buf[0]) {
-            GifFile->Error = D_GIF_ERR_READ_FAILED;
-            return GIF_ERROR;
-        }
-        *NextByte = Buf[1];
-        Buf[1] = 2; /* We use now the second place as last char read! */
-        Buf[0]--;
-    } else {
-        *NextByte = Buf[Buf[1]++];
-        Buf[0]--;
-    }
 
-    return GIF_OK;
+        return GIF_OK;
 }
 
 /******************************************************************************
@@ -1175,19 +1177,22 @@ static int DGifBufferedInput(GifFileType *GifFile, GifByteType *Buf,
  SavedImages may point to the spoilt image and null pointer buffers.
 *******************************************************************************/
 void DGifDecreaseImageCounter(GifFileType *GifFile) {
-    SavedImage *correct_saved_images;
+        SavedImage *correct_saved_images;
 
-    GifFile->ImageCount--;
-    if (GifFile->SavedImages[GifFile->ImageCount].RasterBits != NULL) {
-        free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
-    }
+        GifFile->ImageCount--;
+        if (GifFile->SavedImages[GifFile->ImageCount].RasterBits != NULL) {
+                free(GifFile->SavedImages[GifFile->ImageCount].RasterBits);
+        }
+        if (GifFile->SavedImages[GifFile->ImageCount].ImageDesc.ColorMap != NULL) {
+                GifFreeMapObject(GifFile->SavedImages[GifFile->ImageCount].ImageDesc.ColorMap);
+        }
 
-    // Realloc array according to the new image counter.
-    correct_saved_images = (SavedImage *)reallocarray(
-        GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
-    if (correct_saved_images != NULL) {
-        GifFile->SavedImages = correct_saved_images;
-    }
+        // Realloc array according to the new image counter.
+        correct_saved_images = (SavedImage *)reallocarray(
+            GifFile->SavedImages, GifFile->ImageCount, sizeof(SavedImage));
+        if (correct_saved_images != NULL) {
+                GifFile->SavedImages = correct_saved_images;
+        }
 }
 
 /******************************************************************************
@@ -1196,143 +1201,143 @@ void DGifDecreaseImageCounter(GifFileType *GifFile) {
  first to initialize I/O.  Its inverse is EGifSpew().
 *******************************************************************************/
 int DGifSlurp(GifFileType *GifFile) {
-    size_t ImageSize;
-    GifRecordType RecordType;
-    SavedImage *sp;
-    GifByteType *ExtData;
-    int ExtFunction;
+        size_t ImageSize;
+        GifRecordType RecordType;
+        SavedImage *sp;
+        GifByteType *ExtData;
+        int ExtFunction;
 
-    GifFile->ExtensionBlocks = NULL;
-    GifFile->ExtensionBlockCount = 0;
+        GifFile->ExtensionBlocks = NULL;
+        GifFile->ExtensionBlockCount = 0;
 
-    do {
-        if (DGifGetRecordType(GifFile, &RecordType) == GIF_ERROR) {
-            return (GIF_ERROR);
-        }
+        do {
+                if (DGifGetRecordType(GifFile, &RecordType) == GIF_ERROR) {
+                        return (GIF_ERROR);
+                }
 
-        switch (RecordType) {
-        case IMAGE_DESC_RECORD_TYPE:
-            if (DGifGetImageDesc(GifFile) == GIF_ERROR) {
-                return (GIF_ERROR);
-            }
-
-            sp = &GifFile->SavedImages[GifFile->ImageCount - 1];
-            /* Allocate memory for the image */
-            if (sp->ImageDesc.Width <= 0 ||
-                sp->ImageDesc.Height <= 0 ||
-                sp->ImageDesc.Width >
-                    (INT_MAX / sp->ImageDesc.Height)) {
-                DGifDecreaseImageCounter(GifFile);
-                return GIF_ERROR;
-            }
-            ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
-
-            if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
-                DGifDecreaseImageCounter(GifFile);
-                return GIF_ERROR;
-            }
-            sp->RasterBits = (unsigned char *)reallocarray(
-                NULL, ImageSize, sizeof(GifPixelType));
-
-            if (sp->RasterBits == NULL) {
-                DGifDecreaseImageCounter(GifFile);
-                return GIF_ERROR;
-            }
-
-            if (sp->ImageDesc.Interlace) {
-                int i, j;
-                /*
-                 * The way an interlaced image should be read -
-                 * offsets and jumps...
-                 */
-                static const int InterlacedOffset[] = {0, 4, 2,
-                                                       1};
-                static const int InterlacedJumps[] = {8, 8, 4,
-                                                      2};
-                /* Need to perform 4 passes on the image */
-                for (i = 0; i < 4; i++) {
-                    for (j = InterlacedOffset[i];
-                         j < sp->ImageDesc.Height;
-                         j += InterlacedJumps[i]) {
-                        if (DGifGetLine(
-                                GifFile,
-                                sp->RasterBits +
-                                    j * sp->ImageDesc
-                                            .Width,
-                                sp->ImageDesc.Width) ==
-                            GIF_ERROR) {
-                            DGifDecreaseImageCounter(
-                                GifFile);
-                            return GIF_ERROR;
+                switch (RecordType) {
+                case IMAGE_DESC_RECORD_TYPE:
+                        if (DGifGetImageDesc(GifFile) == GIF_ERROR) {
+                                return (GIF_ERROR);
                         }
-                    }
+
+                        sp = &GifFile->SavedImages[GifFile->ImageCount - 1];
+                        /* Allocate memory for the image */
+                        if (sp->ImageDesc.Width <= 0 ||
+                            sp->ImageDesc.Height <= 0 ||
+                            sp->ImageDesc.Width >
+                                (INT_MAX / sp->ImageDesc.Height)) {
+                                DGifDecreaseImageCounter(GifFile);
+                                return GIF_ERROR;
+                        }
+                        ImageSize = sp->ImageDesc.Width * sp->ImageDesc.Height;
+
+                        if (ImageSize > (SIZE_MAX / sizeof(GifPixelType))) {
+                                DGifDecreaseImageCounter(GifFile);
+                                return GIF_ERROR;
+                        }
+                        sp->RasterBits = (unsigned char *)reallocarray(
+                            NULL, ImageSize, sizeof(GifPixelType));
+
+                        if (sp->RasterBits == NULL) {
+                                DGifDecreaseImageCounter(GifFile);
+                                return GIF_ERROR;
+                        }
+
+                        if (sp->ImageDesc.Interlace) {
+                                int i, j;
+                                /*
+                                 * The way an interlaced image should be read -
+                                 * offsets and jumps...
+                                 */
+                                static const int InterlacedOffset[] = {0, 4, 2,
+                                                                       1};
+                                static const int InterlacedJumps[] = {8, 8, 4,
+                                                                      2};
+                                /* Need to perform 4 passes on the image */
+                                for (i = 0; i < 4; i++) {
+                                        for (j = InterlacedOffset[i];
+                                             j < sp->ImageDesc.Height;
+                                             j += InterlacedJumps[i]) {
+                                                if (DGifGetLine(
+                                                        GifFile,
+                                                        sp->RasterBits +
+                                                            j * sp->ImageDesc
+                                                                    .Width,
+                                                        sp->ImageDesc.Width) ==
+                                                    GIF_ERROR) {
+                                                        DGifDecreaseImageCounter(
+                                                            GifFile);
+                                                        return GIF_ERROR;
+                                                }
+                                        }
+                                }
+                        } else {
+                                if (DGifGetLine(GifFile, sp->RasterBits,
+                                                ImageSize) == GIF_ERROR) {
+                                        DGifDecreaseImageCounter(GifFile);
+                                        return GIF_ERROR;
+                                }
+                        }
+
+                        if (GifFile->ExtensionBlocks) {
+                                sp->ExtensionBlocks = GifFile->ExtensionBlocks;
+                                sp->ExtensionBlockCount =
+                                    GifFile->ExtensionBlockCount;
+
+                                GifFile->ExtensionBlocks = NULL;
+                                GifFile->ExtensionBlockCount = 0;
+                        }
+                        break;
+
+                case EXTENSION_RECORD_TYPE:
+                        if (DGifGetExtension(GifFile, &ExtFunction, &ExtData) ==
+                            GIF_ERROR) {
+                                return (GIF_ERROR);
+                        }
+                        /* Create an extension block with our data */
+                        if (ExtData != NULL) {
+                                if (GifAddExtensionBlock(
+                                        &GifFile->ExtensionBlockCount,
+                                        &GifFile->ExtensionBlocks, ExtFunction,
+                                        ExtData[0], &ExtData[1]) == GIF_ERROR) {
+                                        return (GIF_ERROR);
+                                }
+                        }
+                        for (;;) {
+                                if (DGifGetExtensionNext(GifFile, &ExtData) ==
+                                    GIF_ERROR) {
+                                        return (GIF_ERROR);
+                                }
+                                if (ExtData == NULL) {
+                                        break;
+                                }
+                                /* Continue the extension block */
+                                if (GifAddExtensionBlock(
+                                        &GifFile->ExtensionBlockCount,
+                                        &GifFile->ExtensionBlocks,
+                                        CONTINUE_EXT_FUNC_CODE, ExtData[0],
+                                        &ExtData[1]) == GIF_ERROR) {
+                                        return (GIF_ERROR);
+                                }
+                        }
+                        break;
+
+                case TERMINATE_RECORD_TYPE:
+                        break;
+
+                default: /* Should be trapped by DGifGetRecordType */
+                        break;
                 }
-            } else {
-                if (DGifGetLine(GifFile, sp->RasterBits,
-                                ImageSize) == GIF_ERROR) {
-                    DGifDecreaseImageCounter(GifFile);
-                    return GIF_ERROR;
-                }
-            }
+        } while (RecordType != TERMINATE_RECORD_TYPE);
 
-            if (GifFile->ExtensionBlocks) {
-                sp->ExtensionBlocks = GifFile->ExtensionBlocks;
-                sp->ExtensionBlockCount =
-                    GifFile->ExtensionBlockCount;
-
-                GifFile->ExtensionBlocks = NULL;
-                GifFile->ExtensionBlockCount = 0;
-            }
-            break;
-
-        case EXTENSION_RECORD_TYPE:
-            if (DGifGetExtension(GifFile, &ExtFunction, &ExtData) ==
-                GIF_ERROR) {
+        /* Sanity check for corrupted file */
+        if (GifFile->ImageCount == 0) {
+                GifFile->Error = D_GIF_ERR_NO_IMAG_DSCR;
                 return (GIF_ERROR);
-            }
-            /* Create an extension block with our data */
-            if (ExtData != NULL) {
-                if (GifAddExtensionBlock(
-                        &GifFile->ExtensionBlockCount,
-                        &GifFile->ExtensionBlocks, ExtFunction,
-                        ExtData[0], &ExtData[1]) == GIF_ERROR) {
-                    return (GIF_ERROR);
-                }
-            }
-            for (;;) {
-                if (DGifGetExtensionNext(GifFile, &ExtData) ==
-                    GIF_ERROR) {
-                    return (GIF_ERROR);
-                }
-                if (ExtData == NULL) {
-                    break;
-                }
-                /* Continue the extension block */
-                if (GifAddExtensionBlock(
-                        &GifFile->ExtensionBlockCount,
-                        &GifFile->ExtensionBlocks,
-                        CONTINUE_EXT_FUNC_CODE, ExtData[0],
-                        &ExtData[1]) == GIF_ERROR) {
-                    return (GIF_ERROR);
-                }
-            }
-            break;
-
-        case TERMINATE_RECORD_TYPE:
-            break;
-
-        default: /* Should be trapped by DGifGetRecordType */
-            break;
         }
-    } while (RecordType != TERMINATE_RECORD_TYPE);
 
-    /* Sanity check for corrupted file */
-    if (GifFile->ImageCount == 0) {
-        GifFile->Error = D_GIF_ERR_NO_IMAG_DSCR;
-        return (GIF_ERROR);
-    }
-
-    return (GIF_OK);
+        return (GIF_OK);
 }
 
 /* end */

--- a/jdk/src/share/native/sun/awt/giflib/gif_err.c
+++ b/jdk/src/share/native/sun/awt/giflib/gif_err.c
@@ -26,9 +26,9 @@
 
 gif_err.c - handle error reporting for the GIF library.
 
-SPDX-License-Identifier: MIT
-
 ****************************************************************************/
+// SPDX-License-Identifier: MIT
+// SPDX-File-Copyright-Txt: (C) Copyright 1989 Gershon Elber
 
 #include <stdio.h>
 
@@ -39,83 +39,83 @@ SPDX-License-Identifier: MIT
  Return a string description of  the last GIF error
 *****************************************************************************/
 const char *GifErrorString(int ErrorCode) {
-    const char *Err;
+        const char *Err;
 
-    switch (ErrorCode) {
-    case E_GIF_ERR_OPEN_FAILED:
-        Err = "Failed to open given file";
-        break;
-    case E_GIF_ERR_WRITE_FAILED:
-        Err = "Failed to write to given file";
-        break;
-    case E_GIF_ERR_HAS_SCRN_DSCR:
-        Err = "Screen descriptor has already been set";
-        break;
-    case E_GIF_ERR_HAS_IMAG_DSCR:
-        Err = "Image descriptor is still active";
-        break;
-    case E_GIF_ERR_NO_COLOR_MAP:
-        Err = "Neither global nor local color map";
-        break;
-    case E_GIF_ERR_DATA_TOO_BIG:
-        Err = "Number of pixels bigger than width * height";
-        break;
-    case E_GIF_ERR_NOT_ENOUGH_MEM:
-        Err = "Failed to allocate required memory";
-        break;
-    case E_GIF_ERR_DISK_IS_FULL:
-        Err = "Write failed (disk full?)";
-        break;
-    case E_GIF_ERR_CLOSE_FAILED:
-        Err = "Failed to close given file";
-        break;
-    case E_GIF_ERR_NOT_WRITEABLE:
-        Err = "Given file was not opened for write";
-        break;
-    case D_GIF_ERR_OPEN_FAILED:
-        Err = "Failed to open given file";
-        break;
-    case D_GIF_ERR_READ_FAILED:
-        Err = "Failed to read from given file";
-        break;
-    case D_GIF_ERR_NOT_GIF_FILE:
-        Err = "Data is not in GIF format";
-        break;
-    case D_GIF_ERR_NO_SCRN_DSCR:
-        Err = "No screen descriptor detected";
-        break;
-    case D_GIF_ERR_NO_IMAG_DSCR:
-        Err = "No Image Descriptor detected";
-        break;
-    case D_GIF_ERR_NO_COLOR_MAP:
-        Err = "Neither global nor local color map";
-        break;
-    case D_GIF_ERR_WRONG_RECORD:
-        Err = "Wrong record type detected";
-        break;
-    case D_GIF_ERR_DATA_TOO_BIG:
-        Err = "Number of pixels bigger than width * height";
-        break;
-    case D_GIF_ERR_NOT_ENOUGH_MEM:
-        Err = "Failed to allocate required memory";
-        break;
-    case D_GIF_ERR_CLOSE_FAILED:
-        Err = "Failed to close given file";
-        break;
-    case D_GIF_ERR_NOT_READABLE:
-        Err = "Given file was not opened for read";
-        break;
-    case D_GIF_ERR_IMAGE_DEFECT:
-        Err = "Image is defective, decoding aborted";
-        break;
-    case D_GIF_ERR_EOF_TOO_SOON:
-        Err = "Image EOF detected before image complete";
-        break;
-    default:
-        Err = NULL;
-        break;
-    }
-    return Err;
+        switch (ErrorCode) {
+        case E_GIF_ERR_OPEN_FAILED:
+                Err = "Failed to open given file";
+                break;
+        case E_GIF_ERR_WRITE_FAILED:
+                Err = "Failed to write to given file";
+                break;
+        case E_GIF_ERR_HAS_SCRN_DSCR:
+                Err = "Screen descriptor has already been set";
+                break;
+        case E_GIF_ERR_HAS_IMAG_DSCR:
+                Err = "Image descriptor is still active";
+                break;
+        case E_GIF_ERR_NO_COLOR_MAP:
+                Err = "Neither global nor local color map";
+                break;
+        case E_GIF_ERR_DATA_TOO_BIG:
+                Err = "Number of pixels bigger than width * height";
+                break;
+        case E_GIF_ERR_NOT_ENOUGH_MEM:
+                Err = "Failed to allocate required memory";
+                break;
+        case E_GIF_ERR_DISK_IS_FULL:
+                Err = "Write failed (disk full?)";
+                break;
+        case E_GIF_ERR_CLOSE_FAILED:
+                Err = "Failed to close given file";
+                break;
+        case E_GIF_ERR_NOT_WRITEABLE:
+                Err = "Given file was not opened for write";
+                break;
+        case D_GIF_ERR_OPEN_FAILED:
+                Err = "Failed to open given file";
+                break;
+        case D_GIF_ERR_READ_FAILED:
+                Err = "Failed to read from given file";
+                break;
+        case D_GIF_ERR_NOT_GIF_FILE:
+                Err = "Data is not in GIF format";
+                break;
+        case D_GIF_ERR_NO_SCRN_DSCR:
+                Err = "No screen descriptor detected";
+                break;
+        case D_GIF_ERR_NO_IMAG_DSCR:
+                Err = "No Image Descriptor detected";
+                break;
+        case D_GIF_ERR_NO_COLOR_MAP:
+                Err = "Neither global nor local color map";
+                break;
+        case D_GIF_ERR_WRONG_RECORD:
+                Err = "Wrong record type detected";
+                break;
+        case D_GIF_ERR_DATA_TOO_BIG:
+                Err = "Number of pixels bigger than width * height";
+                break;
+        case D_GIF_ERR_NOT_ENOUGH_MEM:
+                Err = "Failed to allocate required memory";
+                break;
+        case D_GIF_ERR_CLOSE_FAILED:
+                Err = "Failed to close given file";
+                break;
+        case D_GIF_ERR_NOT_READABLE:
+                Err = "Given file was not opened for read";
+                break;
+        case D_GIF_ERR_IMAGE_DEFECT:
+                Err = "Image is defective, decoding aborted";
+                break;
+        case D_GIF_ERR_EOF_TOO_SOON:
+                Err = "Image EOF detected before image complete";
+                break;
+        default:
+                Err = NULL;
+                break;
+        }
+        return Err;
 }
 
 /* end */

--- a/jdk/src/share/native/sun/awt/giflib/gif_hash.h
+++ b/jdk/src/share/native/sun/awt/giflib/gif_hash.h
@@ -26,9 +26,8 @@
 
 gif_hash.h - magfic constants and declarations for GIF LZW
 
-SPDX-License-Identifier: MIT
-
 ******************************************************************************/
+// SPDX-License-Identifier: MIT
 
 #ifndef _GIF_HASH_H_
 #define _GIF_HASH_H_
@@ -46,7 +45,7 @@ SPDX-License-Identifier: MIT
 
 /* The 32 bits of the long are divided into two parts for the key & code:   */
 /* 1. The code is 12 bits as our compression algorithm is limited to 12bits */
-/* 2. The key is 12 bits Prefix code + 8 bit new char or 20 bits.        */
+/* 2. The key is 12 bits Prefix code + 8 bit new char or 20 bits.           */
 /* The key is the upper 20 bits.  The code is the lower 12. */
 #define HT_GET_KEY(l) (l >> 12)
 #define HT_GET_CODE(l) (l & 0x0FFF)
@@ -54,7 +53,7 @@ SPDX-License-Identifier: MIT
 #define HT_PUT_CODE(l) (l & 0x0FFF)
 
 typedef struct GifHashTableType {
-    uint32_t HTable[HT_SIZE];
+        uint32_t HTable[HT_SIZE];
 } GifHashTableType;
 
 GifHashTableType *_InitHashTable(void);

--- a/jdk/src/share/native/sun/awt/giflib/gif_lib.h
+++ b/jdk/src/share/native/sun/awt/giflib/gif_lib.h
@@ -37,9 +37,9 @@ SPDX-License-Identifier: MIT
 extern "C" {
 #endif /* __cplusplus */
 
-#define GIFLIB_MAJOR 5
-#define GIFLIB_MINOR 2
-#define GIFLIB_RELEASE 2
+#define GIFLIB_MAJOR 6
+#define GIFLIB_MINOR 1
+#define GIFLIB_RELEASE 1
 
 #define GIF_ERROR 0
 #define GIF_OK 1
@@ -71,26 +71,26 @@ typedef unsigned int GifPrefixType;
 typedef int GifWord;
 
 typedef struct GifColorType {
-    GifByteType Red, Green, Blue;
+        GifByteType Red, Green, Blue;
 } GifColorType;
 
 typedef struct ColorMapObject {
-    int ColorCount;
-    int BitsPerPixel;
-    bool SortFlag;
-    GifColorType *Colors; /* on malloc(3) heap */
+        int ColorCount;
+        int BitsPerPixel;
+        bool SortFlag;
+        GifColorType *Colors; /* on malloc(3) heap */
 } ColorMapObject;
 
 typedef struct GifImageDesc {
-    GifWord Left, Top, Width, Height; /* Current image dimensions. */
-    bool Interlace;                   /* Sequential/Interlaced lines. */
-    ColorMapObject *ColorMap;         /* The local color map */
+        GifWord Left, Top, Width, Height; /* Current image dimensions. */
+        bool Interlace;                   /* Sequential/Interlaced lines. */
+        ColorMapObject *ColorMap;         /* The local color map */
 } GifImageDesc;
 
 typedef struct ExtensionBlock {
-    int ByteCount;
-    GifByteType *Bytes;            /* on malloc(3) heap */
-    int Function;                  /* The block function code */
+        int ByteCount;
+        GifByteType *Bytes;            /* on malloc(3) heap */
+        int Function;                  /* The block function code */
 #define CONTINUE_EXT_FUNC_CODE 0x00    /* continuation subblock */
 #define COMMENT_EXT_FUNC_CODE 0xfe     /* comment */
 #define GRAPHICS_EXT_FUNC_CODE 0xf9    /* graphics control (GIF89) */
@@ -99,36 +99,36 @@ typedef struct ExtensionBlock {
 } ExtensionBlock;
 
 typedef struct SavedImage {
-    GifImageDesc ImageDesc;
-    GifByteType *RasterBits;         /* on malloc(3) heap */
-    int ExtensionBlockCount;         /* Count of extensions before image */
-    ExtensionBlock *ExtensionBlocks; /* Extensions before image */
+        GifImageDesc ImageDesc;
+        GifByteType *RasterBits;         /* on malloc(3) heap */
+        int ExtensionBlockCount;         /* Count of extensions before image */
+        ExtensionBlock *ExtensionBlocks; /* Extensions before image */
 } SavedImage;
 
 typedef struct GifFileType {
-    GifWord SWidth, SHeight;   /* Size of virtual canvas */
-    GifWord SColorResolution;  /* How many colors can we generate? */
-    GifWord SBackGroundColor;  /* Background color for virtual canvas */
-    GifByteType AspectByte;    /* Used to compute pixel aspect ratio */
-    ColorMapObject *SColorMap; /* Global colormap, NULL if nonexistent. */
-    int ImageCount;            /* Number of current image (both APIs) */
-    GifImageDesc Image;        /* Current image (low-level API) */
-    SavedImage *SavedImages;   /* Image sequence (high-level API) */
-    int ExtensionBlockCount;   /* Count extensions past last image */
-    ExtensionBlock *ExtensionBlocks; /* Extensions past last image */
-    int Error;                       /* Last error condition reported */
-    void *UserData;                  /* hook to attach user data (TVT) */
-    void *Private;                   /* Don't mess with this! */
+        GifWord SWidth, SHeight;   /* Size of virtual canvas */
+        GifWord SColorResolution;  /* How many colors can we generate? */
+        GifWord SBackGroundColor;  /* Background color for virtual canvas */
+        GifByteType AspectByte;    /* Used to compute pixel aspect ratio */
+        ColorMapObject *SColorMap; /* Global colormap, NULL if nonexistent. */
+        int ImageCount;            /* Number of current image (both APIs) */
+        GifImageDesc Image;        /* Current image (low-level API) */
+        SavedImage *SavedImages;   /* Image sequence (high-level API) */
+        int ExtensionBlockCount;   /* Count extensions past last image */
+        ExtensionBlock *ExtensionBlocks; /* Extensions past last image */
+        int Error;                       /* Last error condition reported */
+        void *UserData;                  /* hook to attach user data (TVT) */
+        void *Private;                   /* Don't mess with this! */
 } GifFileType;
 
 #define GIF_ASPECT_RATIO(n) ((n) + 15.0 / 64.0)
 
 typedef enum {
-    UNDEFINED_RECORD_TYPE,
-    SCREEN_DESC_RECORD_TYPE,
-    IMAGE_DESC_RECORD_TYPE, /* Begin with ',' */
-    EXTENSION_RECORD_TYPE,  /* Begin with '!' */
-    TERMINATE_RECORD_TYPE   /* Begin with ';' */
+        UNDEFINED_RECORD_TYPE,
+        SCREEN_DESC_RECORD_TYPE,
+        IMAGE_DESC_RECORD_TYPE, /* Begin with ',' */
+        EXTENSION_RECORD_TYPE,  /* Begin with '!' */
+        TERMINATE_RECORD_TYPE   /* Begin with ';' */
 } GifRecordType;
 
 /* func type to read gif data from arbitrary sources (TVT) */
@@ -144,14 +144,14 @@ typedef int (*OutputFunc)(GifFileType *, const GifByteType *, int);
 ******************************************************************************/
 
 typedef struct GraphicsControlBlock {
-    int DisposalMode;
+        int DisposalMode;
 #define DISPOSAL_UNSPECIFIED 0 /* No disposal specified. */
 #define DISPOSE_DO_NOT 1       /* Leave image in place */
 #define DISPOSE_BACKGROUND 2   /* Set area too background color */
 #define DISPOSE_PREVIOUS 3     /* Restore to previous content */
-    bool UserInputFlag;    /* User confirmation required before disposal */
-    int DelayTime;         /* pre-display delay in 0.01sec units */
-    int TransparentColor;  /* Palette index for transparency, -1 if none */
+        bool UserInputFlag;    /* User confirmation required before disposal */
+        int DelayTime;         /* pre-display delay in 0.01sec units */
+        int TransparentColor;  /* Palette index for transparency, -1 if none */
 #define NO_TRANSPARENT_COLOR -1
 } GraphicsControlBlock;
 
@@ -164,21 +164,21 @@ GifFileType *EGifOpenFileName(const char *GifFileName,
                               const bool GifTestExistence, int *Error);
 GifFileType *EGifOpenFileHandle(const int GifFileHandle, int *Error);
 GifFileType *EGifOpen(void *userPtr, OutputFunc writeFunc, int *Error);
-int EGifSpew(GifFileType *GifFile);
+int EGifSpew(GifFileType *GifFile, int *ErrorCode);
 const char *EGifGetGifVersion(GifFileType *GifFile); /* new in 5.x */
 int EGifCloseFile(GifFileType *GifFile, int *ErrorCode);
 
 #define E_GIF_SUCCEEDED 0
-#define E_GIF_ERR_OPEN_FAILED 1 /* And EGif possible errors. */
-#define E_GIF_ERR_WRITE_FAILED 2
-#define E_GIF_ERR_HAS_SCRN_DSCR 3
-#define E_GIF_ERR_HAS_IMAG_DSCR 4
-#define E_GIF_ERR_NO_COLOR_MAP 5
-#define E_GIF_ERR_DATA_TOO_BIG 6
-#define E_GIF_ERR_NOT_ENOUGH_MEM 7
-#define E_GIF_ERR_DISK_IS_FULL 8
-#define E_GIF_ERR_CLOSE_FAILED 9
-#define E_GIF_ERR_NOT_WRITEABLE 10
+#define E_GIF_ERR_OPEN_FAILED 201 /* And EGif possible errors. */
+#define E_GIF_ERR_WRITE_FAILED 202
+#define E_GIF_ERR_HAS_SCRN_DSCR 203
+#define E_GIF_ERR_HAS_IMAG_DSCR 204
+#define E_GIF_ERR_NO_COLOR_MAP 205
+#define E_GIF_ERR_DATA_TOO_BIG 206
+#define E_GIF_ERR_NOT_ENOUGH_MEM 207
+#define E_GIF_ERR_DISK_IS_FULL 208
+#define E_GIF_ERR_CLOSE_FAILED 209
+#define E_GIF_ERR_NOT_WRITEABLE 210
 
 /* These are legacy.  You probably do not want to call them directly */
 int EGifPutScreenDesc(GifFileType *GifFile, const int GifWidth,

--- a/jdk/src/share/native/sun/awt/giflib/gif_lib_private.h
+++ b/jdk/src/share/native/sun/awt/giflib/gif_lib_private.h
@@ -60,30 +60,30 @@ SPDX-License-Identifier: MIT
 #define IS_WRITEABLE(Private) (Private->FileState & FILE_STATE_WRITE)
 
 typedef struct GifFilePrivateType {
-    GifWord FileState, FileHandle, /* Where all this data goes to! */
-        BitsPerPixel, /* Bits per pixel (Codes uses at least this + 1). */
-        ClearCode,    /* The CLEAR LZ code. */
-        EOFCode,      /* The EOF LZ code. */
-        RunningCode,  /* The next code algorithm can generate. */
-        RunningBits,  /* The number of bits required to represent
-                         RunningCode. */
-        MaxCode1, /* 1 bigger than max. possible code, in RunningBits bits.
-                   */
-        LastCode, /* The code before the current code. */
-        CrntCode, /* Current algorithm code. */
-        StackPtr, /* For character stack (see below). */
-        CrntShiftState;           /* Number of bits in CrntShiftDWord. */
-    unsigned long CrntShiftDWord; /* For bytes decomposition into codes. */
-    unsigned long PixelCount;     /* Number of pixels in image. */
-    FILE *File;                   /* File as stream. */
-    InputFunc Read;               /* function to read gif input (TVT) */
-    OutputFunc Write;             /* function to write gif output (MRB) */
-    GifByteType Buf[256];         /* Compressed input is buffered here. */
-    GifByteType Stack[LZ_MAX_CODE]; /* Decoded pixels are stacked here. */
-    GifByteType Suffix[LZ_MAX_CODE + 1]; /* So we can trace the codes. */
-    GifPrefixType Prefix[LZ_MAX_CODE + 1];
-    GifHashTableType *HashTable;
-    bool gif89;
+        GifWord FileState, FileHandle, /* Where all this data goes to! */
+            BitsPerPixel, /* Bits per pixel (Codes uses at least this + 1). */
+            ClearCode,    /* The CLEAR LZ code. */
+            EOFCode,      /* The EOF LZ code. */
+            RunningCode,  /* The next code algorithm can generate. */
+            RunningBits,  /* The number of bits required to represent
+                             RunningCode. */
+            MaxCode1, /* 1 bigger than max. possible code, in RunningBits bits.
+                       */
+            LastCode, /* The code before the current code. */
+            CrntCode, /* Current algorithm code. */
+            StackPtr, /* For character stack (see below). */
+            CrntShiftState;           /* Number of bits in CrntShiftDWord. */
+        unsigned long CrntShiftDWord; /* For bytes decomposition into codes. */
+        unsigned long PixelCount;     /* Number of pixels in image. */
+        FILE *File;                   /* File as stream. */
+        InputFunc Read;               /* function to read gif input (TVT) */
+        OutputFunc Write;             /* function to write gif output (MRB) */
+        GifByteType Buf[256];         /* Compressed input is buffered here. */
+        GifByteType Stack[LZ_MAX_CODE]; /* Decoded pixels are stacked here. */
+        GifByteType Suffix[LZ_MAX_CODE + 1]; /* So we can trace the codes. */
+        GifPrefixType Prefix[LZ_MAX_CODE + 1];
+        GifHashTableType *HashTable;
+        bool gif89;
 } GifFilePrivateType;
 
 #ifndef HAVE_REALLOCARRAY

--- a/jdk/src/share/native/sun/awt/giflib/gifalloc.c
+++ b/jdk/src/share/native/sun/awt/giflib/gifalloc.c
@@ -26,9 +26,9 @@
 
  GIF construction tools
 
-SPDX-License-Identifier: MIT
-
 ****************************************************************************/
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (C) Eric S. Raymond <esr@thyrsus.com>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -45,14 +45,14 @@ SPDX-License-Identifier: MIT
 
 /* return smallest bitfield size n will fit in */
 int GifBitSize(int n) {
-    register int i;
+        register int i;
 
-    for (i = 1; i <= 8; i++) {
-        if ((1 << i) >= n) {
-            break;
+        for (i = 1; i <= 8; i++) {
+                if ((1 << i) >= n) {
+                        break;
+                }
         }
-    }
-    return (i);
+        return (i);
 }
 
 /******************************************************************************
@@ -64,64 +64,64 @@ int GifBitSize(int n) {
  * ColorMap if that pointer is non-NULL.
  */
 ColorMapObject *GifMakeMapObject(int ColorCount, const GifColorType *ColorMap) {
-    ColorMapObject *Object;
+        ColorMapObject *Object;
 
-    /*** FIXME: Our ColorCount has to be a power of two.  Is it necessary to
-     * make the user know that or should we automatically round up instead?
-     */
-    if (ColorCount != (1 << GifBitSize(ColorCount))) {
-        return ((ColorMapObject *)NULL);
-    }
+        /*** FIXME: Our ColorCount has to be a power of two.  Is it necessary to
+         * make the user know that or should we automatically round up instead?
+         */
+        if (ColorCount != (1 << GifBitSize(ColorCount))) {
+                return ((ColorMapObject *)NULL);
+        }
 
-    Object = (ColorMapObject *)malloc(sizeof(ColorMapObject));
-    if (Object == (ColorMapObject *)NULL) {
-        return ((ColorMapObject *)NULL);
-    }
+        Object = (ColorMapObject *)malloc(sizeof(ColorMapObject));
+        if (Object == (ColorMapObject *)NULL) {
+                return ((ColorMapObject *)NULL);
+        }
 
-    Object->Colors =
-        (GifColorType *)calloc(ColorCount, sizeof(GifColorType));
-    if (Object->Colors == (GifColorType *)NULL) {
-        free(Object);
-        return ((ColorMapObject *)NULL);
-    }
+        Object->Colors =
+            (GifColorType *)calloc(ColorCount, sizeof(GifColorType));
+        if (Object->Colors == (GifColorType *)NULL) {
+                free(Object);
+                return ((ColorMapObject *)NULL);
+        }
 
-    Object->ColorCount = ColorCount;
-    Object->BitsPerPixel = GifBitSize(ColorCount);
-    Object->SortFlag = false;
+        Object->ColorCount = ColorCount;
+        Object->BitsPerPixel = GifBitSize(ColorCount);
+        Object->SortFlag = false;
 
-    if (ColorMap != NULL) {
-        memcpy((char *)Object->Colors, (char *)ColorMap,
-               ColorCount * sizeof(GifColorType));
-    }
+        if (ColorMap != NULL) {
+                memcpy((char *)Object->Colors, (char *)ColorMap,
+                       ColorCount * sizeof(GifColorType));
+        }
 
-    return (Object);
+        return (Object);
 }
 
 /*******************************************************************************
  Free a color map object
 *******************************************************************************/
 void GifFreeMapObject(ColorMapObject *Object) {
-    if (Object != NULL) {
-        (void)free(Object->Colors);
-        (void)free(Object);
-    }
+        if (Object != NULL) {
+                (void)free(Object->Colors);
+                (void)free(Object);
+        }
 }
 
 #ifdef DEBUG
 void DumpColorMap(ColorMapObject *Object, FILE *fp) {
-    if (Object != NULL) {
-        int i, j, Len = Object->ColorCount;
+        if (Object != NULL) {
+                int i, j, Len = Object->ColorCount;
 
-        for (i = 0; i < Len; i += 4) {
-            for (j = 0; j < 4 && j < Len; j++) {
-                (void)fprintf(fp, "%3d: %02x %02x %02x   ",
-                              i + j, Object->Colors[i + j].Red,
-                              Object->Colors[i + j].Green,
-                              Object->Colors[i + j].Blue);
-            }
-            (void)fprintf(fp, "\n");
+                for (i = 0; i < Len; i += 4) {
+                        for (j = 0; j < 4 && j < Len; j++) {
+                                (void)fprintf(fp, "%3d: %02x %02x %02x   ",
+                                              i + j, Object->Colors[i + j].Red,
+                                              Object->Colors[i + j].Green,
+                                              Object->Colors[i + j].Blue);
+                        }
+                        (void)fprintf(fp, "\n");
+                }
         }
-    }
 }
 #endif /* DEBUG */
 
@@ -135,112 +135,112 @@ void DumpColorMap(ColorMapObject *Object, FILE *fp) {
 ColorMapObject *GifUnionColorMap(const ColorMapObject *ColorIn1,
                                  const ColorMapObject *ColorIn2,
                                  GifPixelType ColorTransIn2[]) {
-    int i, j, CrntSlot, RoundUpTo, NewGifBitSize;
-    ColorMapObject *ColorUnion;
-
-    /*
-     * We don't worry about duplicates within either color map; if
-     * the caller wants to resolve those, he can perform unions
-     * with an empty color map.
-     */
-
-    /* Allocate table which will hold the result for sure. */
-    ColorUnion = GifMakeMapObject(
-        MAX(ColorIn1->ColorCount, ColorIn2->ColorCount) * 2, NULL);
-
-    if (ColorUnion == NULL) {
-        return (NULL);
-    }
-
-    /*
-     * Copy ColorIn1 to ColorUnion.
-     */
-    for (i = 0; i < ColorIn1->ColorCount; i++) {
-        ColorUnion->Colors[i] = ColorIn1->Colors[i];
-    }
-    CrntSlot = ColorIn1->ColorCount;
-
-    /*
-     * Potentially obnoxious hack:
-     *
-     * Back CrntSlot down past all contiguous {0, 0, 0} slots at the end
-     * of table 1.  This is very useful if your display is limited to
-     * 16 colors.
-     */
-    while (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
-           ColorIn1->Colors[CrntSlot - 1].Green == 0 &&
-           ColorIn1->Colors[CrntSlot - 1].Blue == 0) {
-        CrntSlot--;
-    }
-
-    /* Copy ColorIn2 to ColorUnion (use old colors if they exist): */
-    for (i = 0; i < ColorIn2->ColorCount && CrntSlot <= 256; i++) {
-        /* Let's see if this color already exists: */
-        for (j = 0; j < ColorIn1->ColorCount; j++) {
-            if (memcmp(&ColorIn1->Colors[j], &ColorIn2->Colors[i],
-                       sizeof(GifColorType)) == 0) {
-                break;
-            }
-        }
-
-        if (j < ColorIn1->ColorCount) {
-            ColorTransIn2[i] = j; /* color exists in Color1 */
-        } else {
-            /* Color is new - copy it to a new slot: */
-            ColorUnion->Colors[CrntSlot] = ColorIn2->Colors[i];
-            ColorTransIn2[i] = CrntSlot++;
-        }
-    }
-
-    if (CrntSlot > 256) {
-        GifFreeMapObject(ColorUnion);
-        return ((ColorMapObject *)NULL);
-    }
-
-    NewGifBitSize = GifBitSize(CrntSlot);
-    RoundUpTo = (1 << NewGifBitSize);
-
-    if (RoundUpTo != ColorUnion->ColorCount) {
-        register GifColorType *Map = ColorUnion->Colors;
+        int i, j, CrntSlot, RoundUpTo, NewGifBitSize;
+        ColorMapObject *ColorUnion;
 
         /*
-         * Zero out slots up to next power of 2.
-         * We know these slots exist because of the way ColorUnion's
-         * start dimension was computed.
+         * We don't worry about duplicates within either color map; if
+         * the caller wants to resolve those, he can perform unions
+         * with an empty color map.
          */
-        for (j = CrntSlot; j < RoundUpTo; j++) {
-            Map[j].Red = Map[j].Green = Map[j].Blue = 0;
+
+        /* Allocate table which will hold the result for sure. */
+        ColorUnion = GifMakeMapObject(
+            MAX(ColorIn1->ColorCount, ColorIn2->ColorCount) * 2, NULL);
+
+        if (ColorUnion == NULL) {
+                return (NULL);
         }
 
-        /* perhaps we can shrink the map? */
-        if (RoundUpTo < ColorUnion->ColorCount) {
-            GifColorType *new_map = (GifColorType *)reallocarray(
-                Map, RoundUpTo, sizeof(GifColorType));
-            if (new_map == NULL) {
+        /*
+         * Copy ColorIn1 to ColorUnion.
+         */
+        for (i = 0; i < ColorIn1->ColorCount; i++) {
+                ColorUnion->Colors[i] = ColorIn1->Colors[i];
+        }
+        CrntSlot = ColorIn1->ColorCount;
+
+        /*
+         * Potentially obnoxious hack:
+         *
+         * Back CrntSlot down past all contiguous {0, 0, 0} slots at the end
+         * of table 1.  This is very useful if your display is limited to
+         * 16 colors.
+         */
+        while (ColorIn1->Colors[CrntSlot - 1].Red == 0 &&
+               ColorIn1->Colors[CrntSlot - 1].Green == 0 &&
+               ColorIn1->Colors[CrntSlot - 1].Blue == 0) {
+                CrntSlot--;
+        }
+
+        /* Copy ColorIn2 to ColorUnion (use old colors if they exist): */
+        for (i = 0; i < ColorIn2->ColorCount && CrntSlot <= 256; i++) {
+                /* Let's see if this color already exists: */
+                for (j = 0; j < ColorIn1->ColorCount; j++) {
+                        if (memcmp(&ColorIn1->Colors[j], &ColorIn2->Colors[i],
+                                   sizeof(GifColorType)) == 0) {
+                                break;
+                        }
+                }
+
+                if (j < ColorIn1->ColorCount) {
+                        ColorTransIn2[i] = j; /* color exists in Color1 */
+                } else {
+                        /* Color is new - copy it to a new slot: */
+                        ColorUnion->Colors[CrntSlot] = ColorIn2->Colors[i];
+                        ColorTransIn2[i] = CrntSlot++;
+                }
+        }
+
+        if (CrntSlot > 256) {
                 GifFreeMapObject(ColorUnion);
                 return ((ColorMapObject *)NULL);
-            }
-            ColorUnion->Colors = new_map;
         }
-    }
 
-    ColorUnion->ColorCount = RoundUpTo;
-    ColorUnion->BitsPerPixel = NewGifBitSize;
+        NewGifBitSize = GifBitSize(CrntSlot);
+        RoundUpTo = (1 << NewGifBitSize);
 
-    return (ColorUnion);
+        if (RoundUpTo != ColorUnion->ColorCount) {
+                register GifColorType *Map = ColorUnion->Colors;
+
+                /*
+                 * Zero out slots up to next power of 2.
+                 * We know these slots exist because of the way ColorUnion's
+                 * start dimension was computed.
+                 */
+                for (j = CrntSlot; j < RoundUpTo; j++) {
+                        Map[j].Red = Map[j].Green = Map[j].Blue = 0;
+                }
+
+                /* perhaps we can shrink the map? */
+                if (RoundUpTo < ColorUnion->ColorCount) {
+                        GifColorType *new_map = (GifColorType *)reallocarray(
+                            Map, RoundUpTo, sizeof(GifColorType));
+                        if (new_map == NULL) {
+                                GifFreeMapObject(ColorUnion);
+                                return ((ColorMapObject *)NULL);
+                        }
+                        ColorUnion->Colors = new_map;
+                }
+        }
+
+        ColorUnion->ColorCount = RoundUpTo;
+        ColorUnion->BitsPerPixel = NewGifBitSize;
+
+        return (ColorUnion);
 }
 
 /*******************************************************************************
  Apply a given color translation to the raster bits of an image
 *******************************************************************************/
 void GifApplyTranslation(SavedImage *Image, const GifPixelType Translation[]) {
-    register int i;
-    register int RasterSize =
-        Image->ImageDesc.Height * Image->ImageDesc.Width;
+        register int i;
+        register int RasterSize =
+            Image->ImageDesc.Height * Image->ImageDesc.Width;
 
-    for (i = 0; i < RasterSize; i++) {
-        Image->RasterBits[i] = Translation[Image->RasterBits[i]];
-    }
+        for (i = 0; i < RasterSize; i++) {
+                Image->RasterBits[i] = Translation[Image->RasterBits[i]];
+        }
 }
 
 /******************************************************************************
@@ -249,56 +249,56 @@ void GifApplyTranslation(SavedImage *Image, const GifPixelType Translation[]) {
 int GifAddExtensionBlock(int *ExtensionBlockCount,
                          ExtensionBlock **ExtensionBlocks, int Function,
                          unsigned int Len, unsigned char ExtData[]) {
-    ExtensionBlock *ep;
+        ExtensionBlock *ep;
 
-    if (*ExtensionBlocks == NULL) {
-        *ExtensionBlocks =
-            (ExtensionBlock *)malloc(sizeof(ExtensionBlock));
-    } else {
-        ExtensionBlock *ep_new = (ExtensionBlock *)reallocarray(
-            *ExtensionBlocks, (*ExtensionBlockCount + 1),
-            sizeof(ExtensionBlock));
-        if (ep_new == NULL) {
-            return (GIF_ERROR);
+        if (*ExtensionBlocks == NULL) {
+                *ExtensionBlocks =
+                    (ExtensionBlock *)malloc(sizeof(ExtensionBlock));
+        } else {
+                ExtensionBlock *ep_new = (ExtensionBlock *)reallocarray(
+                    *ExtensionBlocks, (*ExtensionBlockCount + 1),
+                    sizeof(ExtensionBlock));
+                if (ep_new == NULL) {
+                        return (GIF_ERROR);
+                }
+                *ExtensionBlocks = ep_new;
         }
-        *ExtensionBlocks = ep_new;
-    }
 
-    if (*ExtensionBlocks == NULL) {
-        return (GIF_ERROR);
-    }
+        if (*ExtensionBlocks == NULL) {
+                return (GIF_ERROR);
+        }
 
-    ep = &(*ExtensionBlocks)[(*ExtensionBlockCount)++];
+        ep = &(*ExtensionBlocks)[(*ExtensionBlockCount)++];
 
-    ep->Function = Function;
-    ep->ByteCount = Len;
-    ep->Bytes = (GifByteType *)malloc(ep->ByteCount);
-    if (ep->Bytes == NULL) {
-        return (GIF_ERROR);
-    }
+        ep->Function = Function;
+        ep->ByteCount = Len;
+        ep->Bytes = (GifByteType *)malloc(ep->ByteCount);
+        if (ep->Bytes == NULL) {
+                return (GIF_ERROR);
+        }
 
-    if (ExtData != NULL) {
-        memcpy(ep->Bytes, ExtData, Len);
-    }
+        if (ExtData != NULL) {
+                memcpy(ep->Bytes, ExtData, Len);
+        }
 
-    return (GIF_OK);
+        return (GIF_OK);
 }
 
 void GifFreeExtensions(int *ExtensionBlockCount,
                        ExtensionBlock **ExtensionBlocks) {
-    ExtensionBlock *ep;
+        ExtensionBlock *ep;
 
-    if (*ExtensionBlocks == NULL) {
-        return;
-    }
+        if (*ExtensionBlocks == NULL) {
+                return;
+        }
 
-    for (ep = *ExtensionBlocks;
-         ep < (*ExtensionBlocks + *ExtensionBlockCount); ep++) {
-        (void)free((char *)ep->Bytes);
-    }
-    (void)free((char *)*ExtensionBlocks);
-    *ExtensionBlocks = NULL;
-    *ExtensionBlockCount = 0;
+        for (ep = *ExtensionBlocks;
+             ep < (*ExtensionBlocks + *ExtensionBlockCount); ep++) {
+                (void)free((char *)ep->Bytes);
+        }
+        (void)free((char *)*ExtensionBlocks);
+        *ExtensionBlocks = NULL;
+        *ExtensionBlockCount = 0;
 }
 
 /******************************************************************************
@@ -309,37 +309,37 @@ void GifFreeExtensions(int *ExtensionBlockCount,
  * Frees the last image in the GifFile->SavedImages array
  */
 void FreeLastSavedImage(GifFileType *GifFile) {
-    SavedImage *sp;
+        SavedImage *sp;
 
-    if ((GifFile == NULL) || (GifFile->SavedImages == NULL)) {
-        return;
-    }
+        if ((GifFile == NULL) || (GifFile->SavedImages == NULL)) {
+                return;
+        }
 
-    /* Remove one SavedImage from the GifFile */
-    GifFile->ImageCount--;
-    sp = &GifFile->SavedImages[GifFile->ImageCount];
+        /* Remove one SavedImage from the GifFile */
+        GifFile->ImageCount--;
+        sp = &GifFile->SavedImages[GifFile->ImageCount];
 
-    /* Deallocate its Colormap */
-    if (sp->ImageDesc.ColorMap != NULL) {
-        GifFreeMapObject(sp->ImageDesc.ColorMap);
-        sp->ImageDesc.ColorMap = NULL;
-    }
+        /* Deallocate its Colormap */
+        if (sp->ImageDesc.ColorMap != NULL) {
+                GifFreeMapObject(sp->ImageDesc.ColorMap);
+                sp->ImageDesc.ColorMap = NULL;
+        }
 
-    /* Deallocate the image data */
-    if (sp->RasterBits != NULL) {
-        free((char *)sp->RasterBits);
-    }
+        /* Deallocate the image data */
+        if (sp->RasterBits != NULL) {
+                free((char *)sp->RasterBits);
+        }
 
-    /* Deallocate any extensions */
-    GifFreeExtensions(&sp->ExtensionBlockCount, &sp->ExtensionBlocks);
+        /* Deallocate any extensions */
+        GifFreeExtensions(&sp->ExtensionBlockCount, &sp->ExtensionBlocks);
 
-    /*** FIXME: We could realloc the GifFile->SavedImages structure but is
-     * there a point to it? Saves some memory but we'd have to do it every
-     * time.  If this is used in GifFreeSavedImages then it would be
-     * inefficient (The whole array is going to be deallocated.)  If we just
-     * use it when we want to free the last Image it's convenient to do it
-     * here.
-     */
+        /*** FIXME: We could realloc the GifFile->SavedImages structure but is
+         * there a point to it? Saves some memory but we'd have to do it every
+         * time.  If this is used in GifFreeSavedImages then it would be
+         * inefficient (The whole array is going to be deallocated.)  If we just
+         * use it when we want to free the last Image it's convenient to do it
+         * here.
+         */
 }
 
 /*
@@ -347,103 +347,121 @@ void FreeLastSavedImage(GifFileType *GifFile) {
  */
 SavedImage *GifMakeSavedImage(GifFileType *GifFile,
                               const SavedImage *CopyFrom) {
-    // cppcheck-suppress ctunullpointer
-    if (GifFile->SavedImages == NULL) {
-        GifFile->SavedImages = (SavedImage *)malloc(sizeof(SavedImage));
-    } else {
-        SavedImage *newSavedImages = (SavedImage *)reallocarray(
-            GifFile->SavedImages, (GifFile->ImageCount + 1),
-            sizeof(SavedImage));
-        if (newSavedImages == NULL) {
-            return ((SavedImage *)NULL);
-        }
-        GifFile->SavedImages = newSavedImages;
-    }
-    if (GifFile->SavedImages == NULL) {
-        return ((SavedImage *)NULL);
-    } else {
-        SavedImage *sp = &GifFile->SavedImages[GifFile->ImageCount++];
-
-        if (CopyFrom != NULL) {
-            memcpy((char *)sp, CopyFrom, sizeof(SavedImage));
-
-            /*
-             * Make our own allocated copies of the heap fields in
-             * the copied record.  This guards against potential
-             * aliasing problems.
-             */
-
-            /* first, the local color map */
-            if (CopyFrom->ImageDesc.ColorMap != NULL) {
-                sp->ImageDesc.ColorMap = GifMakeMapObject(
-                    CopyFrom->ImageDesc.ColorMap->ColorCount,
-                    CopyFrom->ImageDesc.ColorMap->Colors);
-                if (sp->ImageDesc.ColorMap == NULL) {
-                    FreeLastSavedImage(GifFile);
-                    return (SavedImage *)(NULL);
-                }
-            }
-
-            /* next, the raster */
-            sp->RasterBits = (unsigned char *)reallocarray(
-                NULL,
-                (CopyFrom->ImageDesc.Height *
-                 CopyFrom->ImageDesc.Width),
-                sizeof(GifPixelType));
-            if (sp->RasterBits == NULL) {
-                FreeLastSavedImage(GifFile);
-                return (SavedImage *)(NULL);
-            }
-            memcpy(sp->RasterBits, CopyFrom->RasterBits,
-                   sizeof(GifPixelType) *
-                       CopyFrom->ImageDesc.Height *
-                       CopyFrom->ImageDesc.Width);
-
-            /* finally, the extension blocks */
-            if (CopyFrom->ExtensionBlocks != NULL) {
-                sp->ExtensionBlocks =
-                    (ExtensionBlock *)reallocarray(
-                        NULL, CopyFrom->ExtensionBlockCount,
-                        sizeof(ExtensionBlock));
-                if (sp->ExtensionBlocks == NULL) {
-                    FreeLastSavedImage(GifFile);
-                    return (SavedImage *)(NULL);
-                }
-                memcpy(sp->ExtensionBlocks,
-                       CopyFrom->ExtensionBlocks,
-                       sizeof(ExtensionBlock) *
-                           CopyFrom->ExtensionBlockCount);
-            }
+        // cppcheck-suppress ctunullpointer
+        if (GifFile->SavedImages == NULL) {
+                GifFile->SavedImages = (SavedImage *)malloc(sizeof(SavedImage));
         } else {
-            memset((char *)sp, '\0', sizeof(SavedImage));
+                SavedImage *newSavedImages = (SavedImage *)reallocarray(
+                    GifFile->SavedImages, (GifFile->ImageCount + 1),
+                    sizeof(SavedImage));
+                if (newSavedImages == NULL) {
+                        return ((SavedImage *)NULL);
+                }
+                GifFile->SavedImages = newSavedImages;
         }
+        if (GifFile->SavedImages == NULL) {
+                return ((SavedImage *)NULL);
+        } else {
+                SavedImage *sp = &GifFile->SavedImages[GifFile->ImageCount++];
 
-        return (sp);
-    }
+                if (CopyFrom != NULL) {
+                        memcpy((char *)sp, CopyFrom, sizeof(SavedImage));
+
+                        /*
+                         * Make our own allocated copies of the heap fields in
+                         * the copied record.  This guards against potential
+                         * aliasing problems.
+                         */
+
+                        /* first, the local color map */
+                        if (CopyFrom->ImageDesc.ColorMap != NULL) {
+                                sp->ImageDesc.ColorMap = GifMakeMapObject(
+                                    CopyFrom->ImageDesc.ColorMap->ColorCount,
+                                    CopyFrom->ImageDesc.ColorMap->Colors);
+                                if (sp->ImageDesc.ColorMap == NULL) {
+                                        FreeLastSavedImage(GifFile);
+                                        return (SavedImage *)(NULL);
+                                }
+                        }
+
+                        /* next, the raster */
+                        sp->RasterBits = (unsigned char *)reallocarray(
+                            NULL,
+                            (CopyFrom->ImageDesc.Height *
+                             CopyFrom->ImageDesc.Width),
+                            sizeof(GifPixelType));
+                        if (sp->RasterBits == NULL) {
+                                FreeLastSavedImage(GifFile);
+                                return (SavedImage *)(NULL);
+                        }
+                        memcpy(sp->RasterBits, CopyFrom->RasterBits,
+                               sizeof(GifPixelType) *
+                                   CopyFrom->ImageDesc.Height *
+                                   CopyFrom->ImageDesc.Width);
+
+                        /* finally, the extension blocks */
+                        if (CopyFrom->ExtensionBlocks != NULL) {
+                                int k;
+                                sp->ExtensionBlocks =
+                                    (ExtensionBlock *)calloc(
+                                        CopyFrom->ExtensionBlockCount,
+                                        sizeof(ExtensionBlock));
+                                if (sp->ExtensionBlocks == NULL) {
+                                        FreeLastSavedImage(GifFile);
+                                        return (SavedImage *)(NULL);
+                                }
+                                for (k = 0; k < CopyFrom->ExtensionBlockCount;
+                                     k++) {
+                                        ExtensionBlock *dst =
+                                            &sp->ExtensionBlocks[k];
+                                        ExtensionBlock *src =
+                                            &CopyFrom->ExtensionBlocks[k];
+                                        dst->Function = src->Function;
+                                        dst->ByteCount = src->ByteCount;
+                                        if (src->ByteCount > 0) {
+                                                dst->Bytes =
+                                                    (GifByteType *)malloc(
+                                                        src->ByteCount);
+                                                if (dst->Bytes == NULL) {
+                                                        FreeLastSavedImage(
+                                                            GifFile);
+                                                        return (SavedImage *)(NULL);
+                                                }
+                                                memcpy(dst->Bytes, src->Bytes,
+                                                       src->ByteCount);
+                                        }
+                                }
+                        }
+                } else {
+                        memset((char *)sp, '\0', sizeof(SavedImage));
+                }
+
+                return (sp);
+        }
 }
 
 void GifFreeSavedImages(GifFileType *GifFile) {
-    SavedImage *sp;
+        SavedImage *sp;
 
-    if ((GifFile == NULL) || (GifFile->SavedImages == NULL)) {
-        return;
-    }
-    for (sp = GifFile->SavedImages;
-         sp < GifFile->SavedImages + GifFile->ImageCount; sp++) {
-        if (sp->ImageDesc.ColorMap != NULL) {
-            GifFreeMapObject(sp->ImageDesc.ColorMap);
-            sp->ImageDesc.ColorMap = NULL;
+        if ((GifFile == NULL) || (GifFile->SavedImages == NULL)) {
+                return;
         }
+        for (sp = GifFile->SavedImages;
+             sp < GifFile->SavedImages + GifFile->ImageCount; sp++) {
+                if (sp->ImageDesc.ColorMap != NULL) {
+                        GifFreeMapObject(sp->ImageDesc.ColorMap);
+                        sp->ImageDesc.ColorMap = NULL;
+                }
 
-        if (sp->RasterBits != NULL) {
-            free((char *)sp->RasterBits);
+                if (sp->RasterBits != NULL) {
+                        free((char *)sp->RasterBits);
+                }
+
+                GifFreeExtensions(&sp->ExtensionBlockCount,
+                                  &sp->ExtensionBlocks);
         }
-
-        GifFreeExtensions(&sp->ExtensionBlockCount,
-                          &sp->ExtensionBlocks);
-    }
-    free((char *)GifFile->SavedImages);
-    GifFile->SavedImages = NULL;
+        free((char *)GifFile->SavedImages);
+        GifFile->SavedImages = NULL;
 }
 
 /* end */

--- a/jdk/src/share/native/sun/awt/giflib/openbsd-reallocarray.c
+++ b/jdk/src/share/native/sun/awt/giflib/openbsd-reallocarray.c
@@ -22,9 +22,8 @@
  * questions.
  */
 
-/*    $OpenBSD: reallocarray.c,v 1.1 2014/05/08 21:43:49 deraadt Exp $    */
 /*
- * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ * SPDX-FileCopyrightText: Copyright (C) 2008 Otto Moerbeek <otto@drijf.net>
  * SPDX-License-Identifier: MIT
  */
 
@@ -44,55 +43,55 @@
 #define MUL_NO_OVERFLOW ((size_t)1 << (sizeof(size_t) * 4))
 
 void *openbsd_reallocarray(void *optr, size_t nmemb, size_t size) {
-    if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
-        nmemb > 0 && SIZE_MAX / nmemb < size) {
-        errno = ENOMEM;
-        return NULL;
-    }
-    /*
-     * Head off variations in realloc behavior on different
-     * platforms (reported by MarkR <mrogers6@users.sf.net>)
-     *
-     * The behaviour of reallocarray is implementation-defined if
-     * nmemb or size is zero. It can return NULL or non-NULL
-     * depending on the platform.
-     * https://www.securecoding.cert.org/confluence/display/c/MEM04-C.Beware+of+zero-lengthallocations
-     *
-     * Here are some extracts from realloc man pages on different platforms.
-     *
-     * void realloc( void memblock, size_t size );
-     *
-     * Windows:
-     *
-     * If there is not enough available memory to expand the block
-     * to the given size, the original block is left unchanged,
-     * and NULL is returned.  If size is zero, then the block
-     * pointed to by memblock is freed; the return value is NULL,
-     * and memblock is left pointing at a freed block.
-     *
-     * OpenBSD:
-     *
-     * If size or nmemb is equal to 0, a unique pointer to an
-     * access protected, zero sized object is returned. Access via
-     * this pointer will generate a SIGSEGV exception.
-     *
-     * Linux:
-     *
-     * If size was equal to 0, either NULL or a pointer suitable
-     * to be passed to free() is returned.
-     *
-     * OS X:
-     *
-     * If size is zero and ptr is not NULL, a new, minimum sized
-     * object is allocated and the original object is freed.
-     *
-     * It looks like images with zero width or height can trigger
-     * this, and fuzzing behaviour will differ by platform, so
-     * fuzzing on one platform may not detect zero-size allocation
-     * problems on other platforms.
-     */
-    if (size == 0 || nmemb == 0) {
-        return NULL;
-    }
-    return realloc(optr, size * nmemb);
+        if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+            nmemb > 0 && SIZE_MAX / nmemb < size) {
+                errno = ENOMEM;
+                return NULL;
+        }
+        /*
+         * Head off variations in realloc behavior on different
+         * platforms (reported by MarkR <mrogers6@users.sf.net>)
+         *
+         * The behaviour of reallocarray is implementation-defined if
+         * nmemb or size is zero. It can return NULL or non-NULL
+         * depending on the platform.
+         * https://www.securecoding.cert.org/confluence/display/c/MEM04-C.Beware+of+zero-lengthallocations
+         *
+         * Here are some extracts from realloc man pages on different platforms.
+         *
+         * void realloc( void memblock, size_t size );
+         *
+         * Windows:
+         *
+         * If there is not enough available memory to expand the block
+         * to the given size, the original block is left unchanged,
+         * and NULL is returned.  If size is zero, then the block
+         * pointed to by memblock is freed; the return value is NULL,
+         * and memblock is left pointing at a freed block.
+         *
+         * OpenBSD:
+         *
+         * If size or nmemb is equal to 0, a unique pointer to an
+         * access protected, zero sized object is returned. Access via
+         * this pointer will generate a SIGSEGV exception.
+         *
+         * Linux:
+         *
+         * If size was equal to 0, either NULL or a pointer suitable
+         * to be passed to free() is returned.
+         *
+         * OS X:
+         *
+         * If size is zero and ptr is not NULL, a new, minimum sized
+         * object is allocated and the original object is freed.
+         *
+         * It looks like images with zero width or height can trigger
+         * this, and fuzzing behaviour will differ by platform, so
+         * fuzzing on one platform may not detect zero-size allocation
+         * problems on other platforms.
+         */
+        if (size == 0 || nmemb == 0) {
+                return NULL;
+        }
+        return realloc(optr, size * nmemb);
 }


### PR DESCRIPTION
**Part of getting giflib updated to 6.1.2 in 8u492** (6.1.2 is in https://github.com/openjdk/jdk8u/pull/89)

This updates the in-tree giflib to 6.1.1. The actual code changes are mostly a clean backport, bar a hunk in `dgif_lib.c` which had to be applied manually due to the Visual Studio 2010 fix we added for [JDK-8328999](https://github.com/openjdk/jdk8u/pull/87). The license file changes needed adapting from the giflib.md file in 11u and later to the THIRD_PARTY_README file in 8u (now only one copy following [JDK-8338144](https://bugs.openjdk.org/browse/JDK-8338144))

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] [JDK-8379256](https://bugs.openjdk.org/browse/JDK-8379256) needs maintainer approval
- [ ] [JDK-8339271](https://bugs.openjdk.org/browse/JDK-8339271) needs maintainer approval

### Issues
 * [JDK-8379256](https://bugs.openjdk.org/browse/JDK-8379256): Update GIFlib to 6.1.1 (**Bug** - P3)
 * [JDK-8339271](https://bugs.openjdk.org/browse/JDK-8339271): giflib attribution correction (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/88.diff">https://git.openjdk.org/jdk8u/pull/88.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/88#issuecomment-4151374729)
</details>
