### PR TITLE
8384158: GHA: Downgrade Windows GHA runners to windows-2022 temporarily

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -682,7 +682,7 @@ jobs:
 
   windows_x64_build:
     name: Windows x64
-    runs-on: "windows-2025"
+    runs-on: "windows-2022"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_windows_x64 != 'false'
 
@@ -845,7 +845,7 @@ jobs:
 
   windows_x86_build:
     name: Windows x86
-    runs-on: "windows-2025"
+    runs-on: "windows-2022"
     needs: prerequisites
     if: needs.prerequisites.outputs.should_run != 'false' && needs.prerequisites.outputs.platform_windows_x86 != 'false'
 
@@ -1028,7 +1028,7 @@ jobs:
 
   windows_x64_test:
     name: Windows x64
-    runs-on: "windows-2025"
+    runs-on: "windows-2022"
     needs:
       - prerequisites
       - windows_x64_build
@@ -1189,7 +1189,7 @@ jobs:
 
   windows_x86_test:
     name: Windows x86
-    runs-on: "windows-2025"
+    runs-on: "windows-2022"
     needs:
       - prerequisites
       - windows_x86_build


### PR DESCRIPTION
This is a backport of the change to use Windows 2022 in spirit rather than like-for-like as 8u does not yet have the GHA restructuring provided by [JDK-8287906](https://bugs.openjdk.org/browse/JDK-8287906) (something I would like to address in due course)

While 8u isn't being hit by the change to Windows 2025 in the same way (likely because it uses Cygwin and Visual Studio 2010 & 2017), I think it would be good to keep the operating systems consistent across major releases to avoid potential issues unique to the newer environment that other JDKs are not yet using.

---------
- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[x\] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue
- \[x\] [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158) needs maintainer approval

### Issue
 * [JDK-8384158](https://bugs.openjdk.org/browse/JDK-8384158): GHA: Downgrade Windows GHA runners to windows-2022 temporarily (**Bug** - P2 - Approved)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk8u.git pull/91/head:pull/91` \
`$ git checkout pull/91`

Update a local copy of the PR: \
`$ git checkout pull/91` \
`$ git pull https://git.openjdk.org/jdk8u.git pull/91/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 91`

View PR using the GUI difftool: \
`$ git pr show -t 91`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk8u/pull/91.diff">https://git.openjdk.org/jdk8u/pull/91.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk8u/pull/91#issuecomment-4772785642)
</details>
